### PR TITLE
Add suport for NCT6687D with ID 0xD592 found on MSI B460M bazooka

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,18 @@ Just add nct6687 into /etc/modules
 ![Fan](./images/fan.png) ![Voltage](./images/voltage.png)
 ## Tested
 
-This module was tested on Ubuntu 20.04 with [Linux Kernel 5.8.18-050818-generic](https://kernel.ubuntu.com/~kernel-ppa/mainline/v5.8.18/) on motherboard [MAG-B550-TOMAHAWK](https://www.msi.com//Motherboard/MAG-B550-TOMAHAWK) running an [AMD 3900X](https://www.amd.com/en/products/cpu/amd-ryzen-9-3900x)
+This module was tested on Ubuntu 20.04 with all kernel availble on motherboard [MAG-B550-TOMAHAWK](https://www.msi.com//Motherboard/MAG-B550-TOMAHAWK) running an [AMD 3900X/AMD 5900X](https://www.amd.com/en/products/cpu/amd-ryzen-9-3900x)
 
-## TODO
+## Other motherboard supported
+
+- Many people have reported compatibility with MB having h410M & H510M chipset from some manufacturer. See issue report.
+
+## CHANGELOG
+
+- Add support for MSI B460M Bazooka having NCT6687 with another device ID
+
+## VERIFIED
 
 **1. Fan speed control**
 
-- Changing fan speed and restore to default value not tested.
-- Becareful probably fan speed could down to 0 RPM
+- Changing fan speed was tested succesfuly by users, see reported issue.

--- a/nct6687.c
+++ b/nct6687.c
@@ -19,6 +19,7 @@
  * Notes:
  *	(1) Total number of voltage and 9 displayed.
  */
+#define DEBUG 1
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
 #include <linux/acpi.h>
@@ -70,7 +71,8 @@ static const char *const nct6687_chip_names[] = {
 #define SIO_REG_ENABLE 0x30		 /* Logical device enable */
 #define SIO_REG_ADDR 0x60		 /* Logical device address (2 bytes) */
 
-#define SIO_NCT6687_ID 0xd592
+#define SIO_NCT6687_ID 0xd451 // 0xd592
+#define SIO_NCT6687D_ID 0xd592
 
 static inline void superio_outb(int ioreg, int reg, int val)
 {
@@ -1034,7 +1036,9 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 
 	val = (superio_inb(sioaddr, SIO_REG_DEVID) << 8) | superio_inb(sioaddr, SIO_REG_DEVREVISION);
 
-	if (val == SIO_NCT6687_ID)
+	pr_debug("found chip ID: 0x%04x\n", val);
+
+	if (val == SIO_NCT6687_ID || val == SIO_NCT6687D_ID)
 	{
 		sio_data->kind = nct6687;
 	}


### PR DESCRIPTION
My owned MSI B460M bazooka embed an NCT6687D with ID 0xD592 detected by the module nct6683 but not supported by the nc6683 module.

Update README too