### PR TITLE
Accept NCT6683D (0xc732)

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -71,6 +71,7 @@ static const char *const nct6687_chip_names[] = {
 #define SIO_REG_ENABLE 0x30		 /* Logical device enable */
 #define SIO_REG_ADDR 0x60		 /* Logical device address (2 bytes) */
 
+#define SIO_NCT6683D_ID 0xc732
 #define SIO_NCT6687_ID 0xd451 // 0xd592
 #define SIO_NCT6687D_ID 0xd592
 
@@ -1038,7 +1039,7 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 
 	pr_debug("found chip ID: 0x%04x\n", val);
 
-	if (val == SIO_NCT6687_ID || val == SIO_NCT6687D_ID)
+	if (val == SIO_NCT6683D_ID || val == SIO_NCT6687_ID || val == SIO_NCT6687D_ID)
 	{
 		sio_data->kind = nct6687;
 	}

--- a/nct6687.c
+++ b/nct6687.c
@@ -1039,7 +1039,7 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 
 	pr_debug("found chip ID: 0x%04x\n", val);
 
-	if (val == SIO_NCT6683D_ID || val == SIO_NCT6687_ID || val == SIO_NCT6687D_ID)
+	if (val == SIO_NCT6683D_ID || val == SIO_NCT6687_ID || val == SIO_NCT6687D_ID || force)
 	{
 		sio_data->kind = nct6687;
 	}

--- a/nct6687.c
+++ b/nct6687.c
@@ -14,6 +14,7 @@
  * Supports the following chips:
  *
  * Chip       #voltage   #fan    #pwm    #temp  chip ID
+ * nct6683    14(1)      8       8       7      0xc732  (partial support)
  * nct6687    14(1)      8       8       7      0xd592
  *
  * Notes:
@@ -40,6 +41,7 @@
 
 enum kinds
 {
+	nct6683,
 	nct6687
 };
 
@@ -48,10 +50,12 @@ module_param(force, bool, 0);
 MODULE_PARM_DESC(force, "Set to one to enable support for unknown vendors");
 
 static const char *const nct6687_device_names[] = {
+	"nct6683",
 	"nct6687",
 };
 
 static const char *const nct6687_chip_names[] = {
+	"NCT6683D",
 	"NCT6687D",
 };
 
@@ -1039,7 +1043,9 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 
 	pr_debug("found chip ID: 0x%04x\n", val);
 
-	if (val == SIO_NCT6683D_ID || val == SIO_NCT6687_ID || val == SIO_NCT6687D_ID || force)
+	if (val == SIO_NCT6683D_ID) {
+		sio_data->kind = nct6683;
+	} else if (val == SIO_NCT6687_ID || val == SIO_NCT6687D_ID || force)
 	{
 		sio_data->kind = nct6687;
 	}


### PR DESCRIPTION
This chip controls the fans on ASRock Taichi B550.

I couldn't get fan control to work with any of the in-tree `nct6*` drivers, but it works with your driver after this change :+1:

Example lm-sensors output:

```
nct6683-isa-0a20
Adapter: ISA adapter
+12V:            0.00 V  (min =  +0.00 V, max =  +0.00 V)
+5V:             0.00 V  (min =  +0.00 V, max =  +0.00 V)
+3.3V:           0.00 V  (min =  +0.00 V, max =  +3.39 V)
CPU Soc:         0.00 V  (min =  +0.00 V, max =  +0.00 V)
CPU Vcore:       0.00 V  (min =  +0.00 V, max =  +0.00 V)
CPU 1P8:         0.00 V  (min =  +0.00 V, max =  +0.00 V)
CPU VDDP:        0.00 V  (min =  +0.00 V, max =  +0.00 V)
DRAM:            0.00 V  (min =  +0.00 V, max =  +0.00 V)
Chipset:         0.00 V  (min =  +0.00 V, max =  +0.00 V)
CPU Fan:          0 RPM  (min =    0 RPM, max =    0 RPM)
Pump Fan:         0 RPM  (min =    0 RPM, max =    0 RPM)
System Fan #1:    0 RPM  (min =    0 RPM, max =    0 RPM)
System Fan #2:  625 RPM  (min =    0 RPM, max =  645 RPM)
System Fan #3:  639 RPM  (min =    0 RPM, max = 1430 RPM)
System Fan #4:    0 RPM  (min =    0 RPM, max =    0 RPM)
System Fan #5:    0 RPM  (min =    0 RPM, max =    0 RPM)
System Fan #6:    0 RPM  (min =    0 RPM, max =    0 RPM)
CPU:            +33.0°C  (low  = +25.0°C, high = +38.0°C)
System:         +39.0°C  (low  = +31.0°C, high = +71.0°C)
VRM MOS:         +0.0°C  (low  =  +0.0°C, high =  +0.0°C)
PCH:             +0.0°C  (low  =  +0.0°C, high =  +0.0°C)
CPU Socket:      +0.0°C  (low  =  +0.0°C, high =  +0.0°C)
PCIe x1:         +0.0°C  (low  =  +0.0°C, high =  +0.0°C)
M2_1:            +0.0°C  (low  =  +0.0°C, high =  +0.0°C)
```

Some notes:
- Most values are missing. From what I've gathered, this board is weird in that it has two `NCT6*` chips. Most sensors (but not fan sensors) appear to be connected to the other one (`nct6798-isa-0290`).
- 3.3V had a non-zero value at some point, but it went away. Not sure why. Might be related to suspend/resume :man_shrugging: 
- "CPU" and "System" sensors seem to be the wrong way around (not sure what "System" refers to here). Probably an lm-sensors config issue?
