### PR TITLE
Fix DKMS building for incorrect versions

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME="nct6687d"
 PACKAGE_VERSION="1"
-MAKE[0]="make dkms/build"
+MAKE[0]="make kver=${kernelver} dkms/build"
 BUILT_MODULE_NAME[0]="nct6687"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/hwmon/"
 AUTOINSTALL="yes"


### PR DESCRIPTION
This commit fixes an issue where the module is built using the currently running kernel version instead of the new one when a DKMS build is triggered by setting the `kver` variable to the new kernel version in dkms.conf.

Fixes #41.