### PR TITLE
Manual voltage configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ dkms/install:
 	sudo modprobe nct6687
 
 dkms/clean:
-	sudo dkms remove nct6687d/1
+	sudo dkms remove nct6687d/1 --all
 	make -C /lib/modules/${kver}/build M=${curpwd} clean
 
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,56 @@ This module was tested on Ubuntu 20.04 with all kernel availble on motherboard [
 ## CHANGELOG
 
 - Add support for MSI B460M Bazooka having NCT6687 with another device ID
+- Add support to use generic voltage input without multiplier, allows sensors custom conf
 <br>
+
+## VOLTAGE MANUAL CONFIGURATION
+
+Some people report that voltage are wrong. The reason is with some motherboard, voltage sensors are not connected on the same nct6687 register.
+
+As example the **VCore** sensor is connected on the **5th** register for AMD but is connected on the **3rd** register for INTEL.
+<br>
+Also the **DIMM** sensor is connected on the **4th** register for AMD but connected to **5th** register for INTEL.
+
+To allow customize voltage configuration you must add **manual=1** parameter passed to the module at load
+
+`sudo sh -c 'echo "nct6687 manual=1" >> /etc/modules'`
+
+And use a sensors conf like this **/etc/sensors.d/B460M-7C83.conf**
+
+```
+# Micro-Star International Co., Ltd.
+# MAG B460M BAZOOKA (MS-7C83)
+
+chip "nct6687-*"
+    label in0         "+12V"
+    label in1         "+5V"
+    label in2         "VCore"
+    label in3         "Voltage #1"
+    label in4         "DIMM"
+    label in5         "CPU I/O"
+    label in6         "CPU SA"
+    label in7         "Voltage #2"
+    label in8         "+3.3V"
+    label in9         "VTT"
+    label in10        "VRef"
+    label in11        "VSB"
+    label in12        "AVSB"
+    label in13        "VBat"
+
+    ignore in3
+    ignore in7
+    ignore in9
+    ignore in10
+    ignore in13
+
+    ignore temp6
+    ignore temp7
+
+    compute in0       (@ * 12), (@ / 12)
+    compute in1       (@ * 5), (@ / 5)
+    compute in4       (@ * 2), (@ / 2)
+```
 
 ## VERIFIED
 **1. Fan speed control**

--- a/nct6687.c
+++ b/nct6687.c
@@ -239,6 +239,38 @@ static struct voltage_reg nct6687_voltage_definition[] = {
 		.multiplier = 1,
 		.label = "Chipset",
 	},
+
+	// CPU SA
+	{
+		.reg = 6,
+		.multiplier = 1,
+		.label = "CPU SA",
+	},
+	// Voltage #2
+	{
+		.reg = 7,
+		.multiplier = 1,
+		.label = "Voltage #2",
+	},
+	// AVCC3
+	{
+		.reg = 8,
+		.multiplier = 1,
+		.label = "AVCC3",
+	},
+	// AVSB
+	{
+		.reg = 12,
+		.multiplier = 1,
+		.label = "AVSB",
+	},
+	// VBAT
+	{
+		.reg = 13,
+		.multiplier = 1,
+		.label = "VBat",
+	},
+
 };
 
 static const char *const nct6687_temp_label[] = {

--- a/nct6687.c
+++ b/nct6687.c
@@ -514,7 +514,7 @@ static void nct6687_update_temperatures(struct nct6687_data *data)
 	{
 		s32 value = (char)nct6687_read(data, NCT6687_REG_TEMP(i));
 		s32 half = (nct6687_read(data, NCT6687_REG_TEMP(i) + 1) >> 7) & 0x1;
-		s32 temperature = (value * 1000) + (5 * half);
+		s32 temperature = (value * 1000) + (500 * half);
 
 		data->temperature[0][i] = temperature;
 		data->temperature[1][i] = MIN(temperature, data->temperature[1][i]);

--- a/nct6687.c
+++ b/nct6687.c
@@ -233,7 +233,7 @@ static struct voltage_reg nct6687_voltage_definition[] = {
 		.multiplier = 2,
 		.label = "DRAM",
 	},
-	// DRAM
+	// Chipset
 	{
 		.reg = 5,
 		.multiplier = 1,

--- a/nct6687.c
+++ b/nct6687.c
@@ -545,7 +545,6 @@ static void nct6687_update_voltage(struct nct6687_data *data)
 	}
 
 	pr_debug("nct6687_update_voltage\n");
-	pr_debug("nct6687_update_voltage\n");
 }
 
 static void nct6687_update_fans(struct nct6687_data *data)

--- a/sensors.d/B460M-7C83.conf
+++ b/sensors.d/B460M-7C83.conf
@@ -1,0 +1,31 @@
+# Micro-Star International Co., Ltd.
+# MAG B460M BAZOOKA (MS-7C83)
+
+chip "nct6687-*"
+    label in0         "+12V"
+    label in1         "+5V"
+    label in2         "VCore"
+    label in3         "Voltage #1"
+    label in4         "DIMM"
+    label in5         "CPU I/O"
+    label in6         "CPU SA"
+    label in7         "Voltage #2"
+    label in8         "+3.3V"
+    label in9         "VTT"
+    label in10        "VRef"
+    label in11        "VSB"
+    label in12        "AVSB"
+    label in13        "VBat"
+
+    ignore in3
+    ignore in7
+    ignore in9
+    ignore in10
+    ignore in13
+
+    ignore temp6
+    ignore temp7
+
+    compute in0       (@ * 12), (@ / 12)
+    compute in1       (@ * 5), (@ / 5)
+    compute in4       (@ * 2), (@ / 2)


### PR DESCRIPTION
This PR permit to configure manually with a sensors conf file voltage label and multiplier.
All voltage are not multiplied and label is like inX