### PR TITLE
FIX: Use the same enum for chipset NCT6686 and NCT6686D

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -1102,10 +1102,8 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 
 	if (val == SIO_NCT6683D_ID) {
 		sio_data->kind = nct6683;
-	} else if (val == SIO_NCT6686_ID) {
+	} else if (val == SIO_NCT6686_ID || val == SIO_NCT6686D_ID) {
 		sio_data->kind = nct6686;
-	} else if (val == SIO_NCT6686D_ID) {
-		sio_data->kind = nct6686d;
 	} else if (val == SIO_NCT6687_ID || val == SIO_NCT6687D_ID || force)
 	{
 		sio_data->kind = nct6687;


### PR DESCRIPTION
Fix issue #59