### PR TITLE
Add `pwm[1-8]_enable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ This module was tested on Ubuntu 20.04 with all kernel available on motherboard 
 
 - Add support for MSI B460M Bazooka having NCT6687 with another device ID
 - Add support to use generic voltage input without multiplier, allows sensors custom conf
+- Support giving fan control back to the firmware
 <br>
 
 ## VOLTAGE MANUAL CONFIGURATION
@@ -215,6 +216,31 @@ echo 0 > pwm6
 echo 128 > pwm6
 # full speed
 echo 255 > pwm6
+```
+
+### `pwm[1-8]_enable`
+
+Gets/sets controls mode of fan/temperature control.
+
+Accepted values:
+ * `1` - manual speed management through `pwm[1-8]`
+ * `99` - whatever automatic mode was configured by firmware
+          (this is a deliberately weird value to be dropped after adding more
+           modes)
+
+Example:
+
+```
+# fix a fan at current speed (`echo pwm6` will be constant from now on)
+echo 1 > pwm6_enable
+# switch back to automatic control set up by firmware (`echo pwm6` is again dynamic after this)
+echo 99 > pwm6_enable
+# switch to ~25% of max speed
+echo 64 > pwm6
+# automatic
+echo 99 > pwm6_enable
+# back to ~25% (it seems to be remembered)
+echo 1 > pwm6_enable
 ```
 
 ## VERIFIED

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ echo 1 > pwm6_enable
 ## VERIFIED
 **1. Fan speed control**
 
-- Changing fan speed was tested succesfuly by users, see reported issue.
+- Changing fan speed was tested successfully by users, see in [reported issues](https://github.com/Fred78290/nct6687d/issues).
 
 ## Issues
 ### ACPI

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ chip "nct6687-*"
     compute in4       (@ * 2), (@ / 2)
 ```
 
+## MODULE PARAMETERS
+
+- **force** (bool) (default: false)
+  Set to enable support for unknown vendors.
+
+- **manual** (bool) (default: false)
+  Set voltage input and voltage label configured with external sensors file.
+  You can use custom labels and ignore inputs without setting this option if
+  you can figure out their names (see which `*_label` contains builtin label).
+
 ## VERIFIED
 **1. Fan speed control**
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,32 @@ chip "nct6687-*"
 
 ## CONFIGURATION VIA SYSFS
 
+In order to be able to use this interface you need to know the path as which
+it's published. The path isn't fixed and depends on the order in which chips are
+registered by the kernel. One way to find it is by device class (`hwmon`) via a
+simple command like this:
+```
+for d in /sys/class/hwmon/*; do echo "$d: $(cat "$d/name")"; done | grep nct6687
+```
+
+Possible output:
+```
+/sys/class/hwmon/hwmon5: nct6687
+```
+
+This means that your base path for examples below is `/sys/class/hwmon/hwmon5`
+(note that adding/removing hardware can change the path, drop `grep` from the
+command above to see all sensors and their relative ordering).
+
+Another way to look it up is by a device (class path actually just points to
+device path) like in:
+
+`cd /sys/devices/platform/nct6687.*/hwmon/hwmon*`
+
+The first asterisk will be expanded to an address (`2592` which is `0xa20` that
+you can see in `sensors` output) and the second one to a number like `5` from
+above.
+
 ### `pwm[1-8]`
 
 Gets/sets PWM duty cycle or DC value that defines fan speed.  Which unit is used

--- a/README.md
+++ b/README.md
@@ -195,6 +195,28 @@ chip "nct6687-*"
   You can use custom labels and ignore inputs without setting this option if
   you can figure out their names (see which `*_label` contains builtin label).
 
+## CONFIGURATION VIA SYSFS
+
+### `pwm[1-8]`
+
+Gets/sets PWM duty cycle or DC value that defines fan speed.  Which unit is used
+depends on what was configured by firmware.
+
+Accepted values: `0`-`255` (slowest to full speed).
+
+Writing to this file changes fan control to manual mode.
+
+Example:
+
+```
+# slow down a fan as much as possible (will stop it if the fan supports zero RPM mode)
+echo 0 > pwm6
+# fix a fan at around half its speed (actual behaviour depends on the fan)
+echo 128 > pwm6
+# full speed
+echo 255 > pwm6
+```
+
 ## VERIFIED
 **1. Fan speed control**
 

--- a/nct6687.c
+++ b/nct6687.c
@@ -819,7 +819,8 @@ static void nct6687_restore_fan_control(struct nct6687_data *data, int index)
 	if (data->_restoreDefaultFanControlRequired[index])
 	{
 		u8 mode = nct6687_read(data, NCT6687_REG_FAN_CTRL_MODE(index));
-		mode = (u8)(mode & ~data->_initialFanControlMode[index]);
+		u8 bitMask = 0x01 << index;
+		mode = (u8)((mode & ~bitMask) | data->_initialFanControlMode[index]);
 
 		nct6687_write(data, NCT6687_REG_FAN_CTRL_MODE(index), mode);
 


### PR DESCRIPTION
* Fix restoring automatic fan mode on module unload.
* Document available parameters and how to use writeable sysfs files.
* Add `pwm[1-8]_enable` to switch between manual/firmware-setup mode.

Closes #78.