### PR TITLE
fix: missing dh-dkms package on debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ debian/changelog: FORCE
 		> $@
 
 deb: debian/changelog
-	sudo apt install -y debhelper dkms
+	sudo apt install -y debhelper dkms dh-dkms
 	dpkg-buildpackage -b -rfakeroot -us -uc
 
 .PHONY: FORCE


### PR DESCRIPTION
When building on a clean bookworm, it fails due to missing dh-dkms package. 