### PR TITLE
dkms: support building for non-running kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 obj-m += nct6687.o
 
 curpwd      := $(shell pwd)
-kver        := $(shell uname -r)
+kver        ?= $(shell uname -r)
 commitcount := $(shell git rev-list --all --count)
 commithash  := $(shell git rev-parse --short HEAD)
 fedoraver := $(shell sed -n 's/.*Fedora release \([^ ]*\).*/\1/p' /etc/fedora-release)


### PR DESCRIPTION
This small tweak allows the dkms build to override the target kernel version to build for a kernel that isn't the current running one.