### PR TITLE
Fix missing dh-dkms on newer Ubuntu distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,10 @@ debian/changelog: FORCE
 		> $@
 
 deb: debian/changelog
-	sudo apt install -y debhelper dkms
+	sudo apt install -y debhelper dkms dh-dkms
+	@if apt-cache show dh-dkms > /dev/null 2>&1; then \
+		sudo apt-get install -y dh-dkms; \
+	fi
 	dpkg-buildpackage -b -rfakeroot -us -uc
 
 .PHONY: FORCE


### PR DESCRIPTION
Extends https://github.com/Fred78290/nct6687d/pull/100 with a conditional check on the availability of the `dh-dkms` package, so as not to fail on Ubuntu 22.04 and other distros in which a standalone package for `dh-dkms` is not available.