### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ debian/changelog: FORCE
 		> $@
 
 deb: debian/changelog
-	sudo apt install -y debhelper dkms dh-dkms
+	sudo apt install -y debhelper dkms
 	@if apt-cache show dh-dkms > /dev/null 2>&1; then \
 		sudo apt-get install -y dh-dkms; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ curpwd      := $(shell pwd)
 kver        ?= $(shell uname -r)
 commitcount := $(shell git rev-list --all --count)
 commithash  := $(shell git rev-parse --short HEAD)
-fedoraver := $(shell sed -n 's/.*Fedora release \([^ ]*\).*/\1/p' /etc/fedora-release)
+fedoraver   := $(shell sed -n 's/.*Fedora release \([^ ]*\).*/\1/p' /etc/fedora-release 2>/dev/null || echo 0)
 
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-obj-m += nct6687.o
+makefile    := obj-m += nct6687.o
 
 curpwd      := $(shell pwd)
 kver        ?= $(shell uname -r)
@@ -10,7 +10,8 @@ fedoraver   := $(shell sed -n 's/.*Fedora release \([^ ]*\).*/\1/p' /etc/fedora-
 build:
 	rm -rf ${curpwd}/${kver}
 	mkdir -p ${curpwd}/${kver}
-	cp ${curpwd}/Makefile ${curpwd}/nct6687.c ${curpwd}/${kver}
+	cp ${curpwd}/nct6687.c ${curpwd}/${kver}
+	echo '${makefile}' > ${curpwd}/${kver}/Makefile
 	cd ${curpwd}/${kver}
 	make -C /lib/modules/${kver}/build M=${curpwd}/${kver} modules
 install: build
@@ -30,7 +31,8 @@ akmod/build:
 	fi
 	sudo dnf install -y rpmdevtools kmodtool
 	mkdir -p ${curpwd}/.tmp/nct6687d-1.0.${commitcount}/nct6687d
-	cp LICENSE Makefile nct6687.c ${curpwd}/.tmp/nct6687d-1.0.${commitcount}/nct6687d
+	cp LICENSE nct6687.c ${curpwd}/.tmp/nct6687d-1.0.${commitcount}/nct6687d
+	echo '${makefile}' > ${curpwd}/.tmp/nct6687d-1.0.${commitcount}/nct6687d/Makefile
 	cd .tmp && tar -czvf nct6687d-1.0.${commitcount}.tar.gz nct6687d-1.0.${commitcount} && cd -
 	mkdir -p ${curpwd}/.tmp/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 	cp ${curpwd}/.tmp/nct6687d-1.0.${commitcount}.tar.gz ${curpwd}/.tmp/rpmbuild/SOURCES/
@@ -54,7 +56,8 @@ dkms/build:
 dkms/install:
 	rm -rf ${curpwd}/dkms
 	mkdir -p ${curpwd}/dkms
-	cp ${curpwd}/dkms.conf ${curpwd}/Makefile ${curpwd}/nct6687.c ${curpwd}/dkms
+	cp ${curpwd}/dkms.conf ${curpwd}/nct6687.c ${curpwd}/dkms
+	echo '${makefile}' > ${curpwd}/dkms/Makefile
 	sudo rm -rf /usr/src/nct6687d-1
 	sudo cp -rT dkms /usr/src/nct6687d-1
 	sudo dkms install nct6687d/1

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,5 @@
 PACKAGE_NAME="nct6687d"
 PACKAGE_VERSION="1"
-MAKE[0]="make kver=${kernelver} dkms/build"
 BUILT_MODULE_NAME[0]="nct6687"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/hwmon/"
 AUTOINSTALL="yes"


### PR DESCRIPTION
Reduces dkms' `Makefile` to a trivial `obj-m += nct6687.o`, thus avoiding running any `git` or `sed` commands during compilation of the module.  Also silences error on non-Fedora distributions for an in-tree build.

Fixes https://github.com/Fred78290/nct6687d/pull/126 installing `dh-dkms` unconditionally.

Closes https://github.com/Fred78290/nct6687d/issues/124 and addresses https://github.com/Fred78290/nct6687d/pull/109#issuecomment-2834269708.