### PR TITLE
Bring back copying of Makefile as is

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-makefile    := obj-m += nct6687.o
+obj-m += nct6687.o
 
 curpwd      := $(shell pwd)
 kver        ?= $(shell uname -r)
@@ -10,8 +10,7 @@ fedoraver   := $(shell sed -n 's/.*Fedora release \([^ ]*\).*/\1/p' /etc/fedora-
 build:
 	rm -rf ${curpwd}/${kver}
 	mkdir -p ${curpwd}/${kver}
-	cp ${curpwd}/nct6687.c ${curpwd}/${kver}
-	echo '${makefile}' > ${curpwd}/${kver}/Makefile
+	cp ${curpwd}/Makefile ${curpwd}/nct6687.c ${curpwd}/${kver}
 	cd ${curpwd}/${kver}
 	make -C /lib/modules/${kver}/build M=${curpwd}/${kver} modules
 install: build
@@ -31,8 +30,7 @@ akmod/build:
 	fi
 	sudo dnf install -y rpmdevtools kmodtool
 	mkdir -p ${curpwd}/.tmp/nct6687d-1.0.${commitcount}/nct6687d
-	cp LICENSE nct6687.c ${curpwd}/.tmp/nct6687d-1.0.${commitcount}/nct6687d
-	echo '${makefile}' > ${curpwd}/.tmp/nct6687d-1.0.${commitcount}/nct6687d/Makefile
+	cp LICENSE Makefile nct6687.c ${curpwd}/.tmp/nct6687d-1.0.${commitcount}/nct6687d
 	cd .tmp && tar -czvf nct6687d-1.0.${commitcount}.tar.gz nct6687d-1.0.${commitcount} && cd -
 	mkdir -p ${curpwd}/.tmp/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 	cp ${curpwd}/.tmp/nct6687d-1.0.${commitcount}.tar.gz ${curpwd}/.tmp/rpmbuild/SOURCES/
@@ -56,8 +54,7 @@ dkms/build:
 dkms/install:
 	rm -rf ${curpwd}/dkms
 	mkdir -p ${curpwd}/dkms
-	cp ${curpwd}/dkms.conf ${curpwd}/nct6687.c ${curpwd}/dkms
-	echo '${makefile}' > ${curpwd}/dkms/Makefile
+	cp ${curpwd}/dkms.conf ${curpwd}/Makefile ${curpwd}/nct6687.c ${curpwd}/dkms
 	sudo rm -rf /usr/src/nct6687d-1
 	sudo cp -rT dkms /usr/src/nct6687d-1
 	sudo dkms install nct6687d/1

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ obj-m += nct6687.o
 
 curpwd      := $(shell pwd)
 kver        ?= $(shell uname -r)
-commitcount := $(shell git rev-list --all --count)
-commithash  := $(shell git rev-parse --short HEAD)
+commitcount := $(shell git rev-list --all --count 2>/dev/null)
+commithash  := $(shell git rev-parse --short HEAD 2>/dev/null)
 fedoraver   := $(shell sed -n 's/.*Fedora release \([^ ]*\).*/\1/p' /etc/fedora-release 2>/dev/null || echo 0)
 
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,6 @@
 PACKAGE_NAME="nct6687d"
 PACKAGE_VERSION="1"
+MAKE[0]="make kver=${kernelver} dkms/build"
 BUILT_MODULE_NAME[0]="nct6687"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/hwmon/"
 AUTOINSTALL="yes"


### PR DESCRIPTION
Instead just silence errors from `git` to not see confusing output.

Closes #128, closes #127.