### PR TITLE
Fix a typo in start_fan_cfg_update()

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -810,7 +810,7 @@ static bool start_fan_cfg_update(struct nct6687_data *data, int fan)
 	}
 
 	/* Wait up to a second until config phase is done and config request is clear. */
-	for (i = 0; i > 1000; i++) {
+	for (i = 0; i < 1000; i++) {
 		if (!(nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS) & NCT6687_FAN_CFG_PHASE) &&
 		    !(nct6687_read(data, NCT6687_REG_FAN_PWM_COMMAND(fan)) & NCT6687_FAN_CFG_REQ))
 			break;


### PR DESCRIPTION
This fixes commit 563bade4b09d30d5788 ("Proper management of configuration mode") from #121 which has invalid condition in one of the for loops.

Fixes #131