### PR TITLE
Add MSI X870/B850/Z890 system fan control support

### DIFF
--- a/TESTING_RESULTS.md
+++ b/TESTING_RESULTS.md
@@ -1,0 +1,49 @@
+# nct6687d MSI X870 SYS Fan Control - Testing Results
+
+## Hardware
+- **Motherboard**: MSI MAG X870E TOMAHAWK WIFI
+- **Chip**: Nuvoton NCT6687D (EC firmware version 0.0 build 11/13/24)
+- **Kernel**: Linux 6.17.4-arch2-1
+- **Driver**: nct6687d with MSI X870 SYS fan control patch
+
+## Problem
+System fans (SYS_FAN1/2/3) on MSI X870 boards were not controllable via Linux. Only CPU_FAN and PUMP_FAN responded to PWM changes.
+
+## Root Cause
+The nct6687d driver used generic PWM control registers (0xA28+x) for all fans. MSI's X870 boards use different control registers for system fans, discovered through reverse engineering by the LibreHardwareMonitor project.
+
+## Solution
+Added per-fan PWM write control registers to `nct6687_fan_config` struct:
+- CPU/PUMP fans: 0xA28, 0xA29 (unchanged)
+- SYS fans: 0xC70, 0xC58, 0xC40, 0xC28, 0xC10, 0xBF8
+
+## Test Results
+
+### Before Patch
+- SYS_FAN1 (rear exhaust): 0 RPM, no control
+- SYS_FAN2 (front lower): 554 RPM, no control
+- SYS_FAN3 (front upper): 560 RPM, no control
+
+### After Patch
+All fans fully controllable:
+- **SYS_FAN1**: 0 → 1212 RPM (immediate response to PWM changes)
+- **SYS_FAN2**: 554 → 1060 RPM (immediate response)
+- **SYS_FAN3**: 560 → 1055 RPM (immediate response)
+
+### CoolerControl Integration
+- Successfully applies fan curves/fixed speeds
+- Fans audibly respond to setting changes
+- "MANUAL CONTROL" mode working correctly
+
+## Commits
+- `8ec1ea7` - Add per-fan PWM control registers for MSI X870 boards
+- `8b0782c` - Fix MSI X870 SYS fan control register addresses
+
+## Credits
+Register addresses reverse-engineered from:
+- LibreHardwareMonitor project: https://github.com/LibreHardwareMonitor/LibreHardwareMonitor
+- Specifically Nct677X.cs NCT6687DR implementation
+- Thanks to @Alcolawl and contributors
+
+## Status
+✅ **WORKING** - Ready for upstream PR to https://github.com/Fred78290/nct6687d

--- a/nct6687.c
+++ b/nct6687.c
@@ -163,7 +163,7 @@ static inline void superio_exit(int ioreg)
 #define NCT6687_REG_VOLTAGE(x) (0x120 + (x)*2)
 #define NCT6687_REG_FAN_RPM(x) (nct6687_fan_config_active[x].reg_rpm)
 #define NCT6687_REG_PWM(x) (nct6687_fan_config_active[x].reg_pwm)
-#define NCT6687_REG_PWM_WRITE(x) (0xa28 + (x))
+#define NCT6687_REG_PWM_WRITE(x) (nct6687_fan_config_active[x].reg_pwm_write)
 
 #define NCT6687_HWM_CFG 0x180
 
@@ -322,31 +322,33 @@ struct nct6687_fan_config
 {
 	u16 reg_rpm;
 	u16 reg_pwm;
+	u16 reg_pwm_write;  // PWM write/control register
 	const char *label;
 };
 
 static struct nct6687_fan_config nct6687_fan_config_default[] = {
-	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .label = "CPU Fan"}, // CPU Fan
-	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .label = "Pump Fan"}, // PUMP Fan
-	{ .reg_rpm = 0x144, .reg_pwm = 0x162, .label = "System Fan #1"}, // SYS Fan 1, Nil on others
-	{ .reg_rpm = 0x146, .reg_pwm = 0x163, .label = "System Fan #2"}, // SYS Fan 2, EZConn on others
-	{ .reg_rpm = 0x148, .reg_pwm = 0x164, .label = "System Fan #3"}, // SYS Fan 3
-	{ .reg_rpm = 0x14A, .reg_pwm = 0x165, .label = "System Fan #4"}, // SYS Fan 4
-	{ .reg_rpm = 0x14C, .reg_pwm = 0x166, .label = "System Fan #5"}, // SYS Fan 5
-	{ .reg_rpm = 0x14E, .reg_pwm = 0x167, .label = "System Fan #6"}, // SYS Fan 6
+	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"}, // CPU Fan
+	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"}, // PUMP Fan
+	{ .reg_rpm = 0x144, .reg_pwm = 0x162, .reg_pwm_write = 0xA2A, .label = "System Fan #1"}, // SYS Fan 1, Nil on others
+	{ .reg_rpm = 0x146, .reg_pwm = 0x163, .reg_pwm_write = 0xA2B, .label = "System Fan #2"}, // SYS Fan 2, EZConn on others
+	{ .reg_rpm = 0x148, .reg_pwm = 0x164, .reg_pwm_write = 0xA2C, .label = "System Fan #3"}, // SYS Fan 3
+	{ .reg_rpm = 0x14A, .reg_pwm = 0x165, .reg_pwm_write = 0xA2D, .label = "System Fan #4"}, // SYS Fan 4
+	{ .reg_rpm = 0x14C, .reg_pwm = 0x166, .reg_pwm_write = 0xA2E, .label = "System Fan #5"}, // SYS Fan 5
+	{ .reg_rpm = 0x14E, .reg_pwm = 0x167, .reg_pwm_write = 0xA2F, .label = "System Fan #6"}, // SYS Fan 6
 };
 
 //some MSI B850, X870, and Z890 boards
-//pwm registers copied from https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1644/files but still don't seem to be correct
+//PWM registers and control registers from LibreHardwareMonitor NCT6687DR (current master)
+//https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
 static struct nct6687_fan_config nct6687_fan_config_msi_alt[] = {
-	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .label = "CPU Fan"},
-	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .label = "Pump Fan"},
-	{ .reg_rpm = 0x15E, .reg_pwm = 0xE05, .label = "System Fan #1"},
-	{ .reg_rpm = 0x15C, .reg_pwm = 0xE04, .label = "System Fan #2"},
-	{ .reg_rpm = 0x15A, .reg_pwm = 0xE03, .label = "System Fan #3"},
-	{ .reg_rpm = 0x158, .reg_pwm = 0xE02, .label = "System Fan #4"},
-	{ .reg_rpm = 0x156, .reg_pwm = 0xE01, .label = "System Fan #5"},
-	{ .reg_rpm = 0x154, .reg_pwm = 0xE00, .label = "System Fan #6"},
+	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},
+	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},
+	{ .reg_rpm = 0x15E, .reg_pwm = 0xE05, .reg_pwm_write = 0xC70, .label = "System Fan #1"},
+	{ .reg_rpm = 0x15C, .reg_pwm = 0xE04, .reg_pwm_write = 0xC58, .label = "System Fan #2"},
+	{ .reg_rpm = 0x15A, .reg_pwm = 0xE03, .reg_pwm_write = 0xC40, .label = "System Fan #3"},
+	{ .reg_rpm = 0x158, .reg_pwm = 0xE02, .reg_pwm_write = 0xC28, .label = "System Fan #4"},
+	{ .reg_rpm = 0x156, .reg_pwm = 0xE01, .reg_pwm_write = 0xC10, .label = "System Fan #5"},
+	{ .reg_rpm = 0x154, .reg_pwm = 0xE00, .reg_pwm_write = 0xBF8, .label = "System Fan #6"},
 };
 
 enum nct6687_fan_config_type {


### PR DESCRIPTION
# Add MSI X870/B850/Z890 system fan control support

## Summary
This PR enables PWM control for system fans (SYS_FAN1-6) on MSI B850, X870, and Z890 motherboards using the Nuvoton NCT6687D chip.

## Problem
System fans on MSI's newer AM5/LGA1851 boards are not controllable from Linux with the current driver. Only CPU_FAN and PUMP_FAN respond to PWM changes. Writing to `pwmN` sysfs attributes has no effect on system fan speeds - the values are immediately reset or ignored.

This affects users of:
- MSI B850 series (MAG B850 TOMAHAWK, etc.)
- MSI X870 series (MAG X870E TOMAHAWK WIFI, etc.)
- MSI Z890 series (MPG Z890 CARBON WIFI, etc.)

Related upstream issues:
- https://github.com/Fred78290/nct6687d/issues/107
- https://github.com/Fred78290/nct6687d/issues/138

## Root Cause
MSI's implementation uses different PWM control registers for system fans compared to standard NCT6687D boards. The current driver uses a single register offset formula (`0xA28 + fan_index`) for all fans, but MSI boards require specific per-fan control registers.

## Solution
This patch adds per-fan PWM write control registers to the `nct6687_fan_config` structure:

**For standard boards (unchanged):**
- All fans: `0xA28` + fan index

**For MSI msi_alt1 configuration (new):**
- CPU_FAN: `0xA28`
- PUMP_FAN: `0xA29`
- SYS_FAN1-6: `0xC70`, `0xC58`, `0xC40`, `0xC28`, `0xC10`, `0xBF8`

## Register Address Source
These exact register addresses are from the [LibreHardwareMonitor](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor) project's NCT6687DR implementation, which has proven fan control on Windows for the same MSI motherboards.

**Reference:**
- File: [`Nct677X.cs`](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs)
- Lines: 74-89 (`FAN_PWM_COMMAND_REG` array for NCT6687DR)

The register discovery was done by the LibreHardwareMonitor team through reverse engineering MSI's Windows drivers. Credit to [@Alcolawl](https://github.com/Alcolawl) and other LHM contributors for their work on this.

## Testing
**Hardware:** MSI MAG X870E TOMAHAWK WIFI
**Kernel:** Linux 6.17.4-arch2-1
**Fan Control Software:** CoolerControl

**Results:**
- ✅ All 3 case fans now respond immediately to PWM changes
- ✅ CoolerControl successfully applies fan curves and fixed speeds
- ✅ Fans audibly respond to setting adjustments
- ✅ Manual PWM writes via sysfs work correctly
- ✅ No regression on CPU_FAN/PUMP_FAN control

Before patch:
- SYS_FAN1 (rear exhaust): 0 RPM, no control
- SYS_FAN2 (front lower): 554 RPM, no control
- SYS_FAN3 (front upper): 560 RPM, no control

After patch:
- SYS_FAN1: 0 → 1212 RPM (fully controllable)
- SYS_FAN2: 554 → 1060 RPM (fully controllable)
- SYS_FAN3: 560 → 1055 RPM (fully controllable)

See [`TESTING_RESULTS.md`](https://github.com/aaronsb/nct6687d/blob/fix-x870-sysfan-control/TESTING_RESULTS.md) for detailed test data.

## Changes
- Added `reg_pwm_write` field to `nct6687_fan_config` struct
- Updated `nct6687_fan_config_default[]` with standard register addresses
- Updated `nct6687_fan_config_msi_alt[]` with MSI-specific register addresses
- Modified `NCT6687_REG_PWM_WRITE` macro to use per-fan configuration
- Added `TESTING_RESULTS.md` with test methodology and results

## Backward Compatibility
This change is backward compatible:
- Standard boards continue using the existing register formula
- Only MSI boards with `fan_config=msi_alt1` use the new addresses
- No changes to default behavior or module parameters

## Request for Testing
If you have an MSI B850/X870/Z890 board, please test this patch and report results. Additional boards that may benefit:
- MSI MAG B850M MORTAR WIFI
- MSI MPG X870E CARBON WIFI
- MSI MPG Z890 EDGE TI WIFI
- Other MSI boards using NCT6687D with the `msi_alt1` config

---

**Note:** This PR description was collaboratively developed with AI assistance (Claude Code) and myself, @aaronsb. All technical content, register addresses, and testing results are accurate and verified on real hardware.
