### PR TITLE
feat: Add MSI fan brute force control and more automatic detection for B840/B850/X870/Z890 boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ chip "nct6687-*"
   
   Motherboards which need this will show CPU/Pump RPMs but no data on System fans.
 
-  `msi_alt1` is automatically enabled for supported MSI motherboards (MAG Z890 TOMAHAWK WIFI, 
-  PRO Z890-A WIFI, MPG Z890 CARBON WIFI, MPG Z890I EDGE TI WIFI, PRO X870-P WIFI, and several others).
+  `msi_alt1` is automatically enabled for 36 supported MSI motherboards including B840, B850, X870, 
+  X870E, and Z890 series (MAG Z890 TOMAHAWK WIFI, PRO Z890-A WIFI, MPG Z890 CARBON WIFI, and many others).
   Manual configuration is only needed for unsupported boards.
 
 - **msi_fan_brute_force** (bool) (default: false) **[ALPHA]**

--- a/README.md
+++ b/README.md
@@ -201,7 +201,18 @@ chip "nct6687-*"
   
   Motherboards which need this will show CPU/Pump RPMs but no data on System fans.
 
-  `msi_alt1` is known to work with come MSI Motherboards using the MSI B850, X870, or Z890 chipsets
+  `msi_alt1` is automatically enabled for supported MSI motherboards (MAG Z890 TOMAHAWK WIFI, 
+  PRO Z890-A WIFI, MPG Z890 CARBON WIFI, MPG Z890I EDGE TI WIFI, PRO X870-P WIFI, and several others).
+  Manual configuration is only needed for unsupported boards.
+
+- **msi_fan_brute_force** (bool) (default: false) **[ALPHA]**
+  For MSI motherboards with `msi_alt1` configuration: When enabled, writes PWM values to all 7 fan 
+  curve control points. This may help with fan control on some MSI boards where standard PWM writes 
+  don't take effect immediately. Only affects system fans controlled by the BIOS. Not the CPU fan or pump fan. 
+  
+  This implementation is based on register mappings from [LibreHardwareMonitor](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor).
+  
+  Usage: `modprobe nct6687 msi_fan_brute_force=1`
 
 ## CONFIGURATION VIA SYSFS
 
@@ -295,4 +306,10 @@ systemd-modules-load[339]: Failed to insert module 'nct6687': No such device
 * add `softdep nct6687 pre: i2c_i801` to e.g. `/etc/modprobe.d/sensors.conf`.
 
 ### Only CPU & Pump show RPM values
-If you have an MSI motherboard, try using module parameter `fan_config=msi_alt1`
+On MSI motherboards, `msi_alt1` configuration is automatically detected and enabled.
+You can verify this in `dmesg` after loading the module:
+```
+nct6687 nct6687.2592: Detected MSI board; using alternative fan configuration (msi_alt1)
+```
+
+If you have a non-MSI motherboard with this issue, try using module parameter `fan_config=msi_alt1` manually.

--- a/nct6687.c
+++ b/nct6687.c
@@ -7,10 +7,10 @@
  *
  * Derived from nct6683 driver
  * Copyright (C) 2013  Guenter Roeck <linux@roeck-us.net>
- * 
+ *
  * Inspired of LibreHardwareMonitor
  * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor
- * 
+ *
  * Supports the following chips:
  *
  * Chip       #voltage   #fan    #pwm    #temp  chip ID
@@ -41,15 +41,15 @@
 #define DRVNAME "nct6687"
 
 #ifndef MIN
-#define MIN(a,b) (((a)<(b))?(a):(b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
 #ifndef MAX
-#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif
 
-#define NCT6687_FAN_CURVE_POINTS 7 	   	// Number of points in the fan curve registers for each fan.
-#define NCT6687_FAN_CURVE_POINT_SIZE 2 	// Each curve point occupies 2 registers
+#define NCT6687_FAN_CURVE_POINTS 7	   // Number of points in the fan curve registers for each fan.
+#define NCT6687_FAN_CURVE_POINT_SIZE 2 // Each curve point occupies 2 registers
 #define NCT6687_FIRST_SYSTEM_FAN_INDEX 2
 
 /*
@@ -60,6 +60,7 @@
  * - register1: PWM value or unused
  *
  * Based on reverse engineering from LibreHardwareMonitor.
+ * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
  */
 struct nct6687_fan_curve_point
 {
@@ -120,12 +121,12 @@ static const char *const nct6687_chip_names[] = {
 #define SIO_REG_ENABLE 0x30		 /* Logical device enable */
 #define SIO_REG_ADDR 0x60		 /* Logical device address (2 bytes) */
 
-#define SIO_NCT6681_ID          0xb270  /* for later */
-#define SIO_NCT6683_ID          0xc730
-#define SIO_NCT6686_ID          0xd440
-#define SIO_NCT6687D_ID         0xd450  /* NCT6687 ???*/
-#define SIO_NCT6687_ID          0xd590
-#define SIO_ID_MASK             0xFFF0
+#define SIO_NCT6681_ID 0xb270 /* for later */
+#define SIO_NCT6683_ID 0xc730
+#define SIO_NCT6686_ID 0xd440
+#define SIO_NCT6687D_ID 0xd450 /* NCT6687 ???*/
+#define SIO_NCT6687_ID 0xd590
+#define SIO_ID_MASK 0xFFF0
 
 static inline void superio_outb(int ioreg, int reg, int val)
 {
@@ -183,8 +184,8 @@ static inline void superio_exit(int ioreg)
 #define NCT6687_NUM_REG_FAN 8
 #define NCT6687_NUM_REG_PWM 8
 
-#define NCT6687_REG_TEMP(x) (0x100 + (x)*2)
-#define NCT6687_REG_VOLTAGE(x) (0x120 + (x)*2)
+#define NCT6687_REG_TEMP(x) (0x100 + (x) * 2)
+#define NCT6687_REG_VOLTAGE(x) (0x120 + (x) * 2)
 #define NCT6687_REG_FAN_RPM(x) (nct6687_fan_config_active[x].reg_rpm)
 #define NCT6687_REG_PWM(x) (nct6687_fan_config_active[x].reg_pwm)
 #define NCT6687_REG_PWM_WRITE(x) (nct6687_fan_config_active[x].reg_pwm_write)
@@ -195,27 +196,27 @@ static inline void superio_exit(int ioreg)
 #define NCT6687_REG_FANIN_CFG(x) (0xA00 + (x))
 #define NCT6687_REG_FANOUT_CFG(x) (0x1d0 + (x))
 
-#define NCT6687_REG_TEMP_HYST(x) (0x330 + (x))	/* 8 bit */
-#define NCT6687_REG_TEMP_MAX(x) (0x350 + (x))	/* 8 bit */
-#define NCT6687_REG_MON_HIGH(x) (0x370 + (x)*2) /* 8 bit */
-#define NCT6687_REG_MON_LOW(x) (0x371 + (x)*2)	/* 8 bit */
+#define NCT6687_REG_TEMP_HYST(x) (0x330 + (x))	  /* 8 bit */
+#define NCT6687_REG_TEMP_MAX(x) (0x350 + (x))	  /* 8 bit */
+#define NCT6687_REG_MON_HIGH(x) (0x370 + (x) * 2) /* 8 bit */
+#define NCT6687_REG_MON_LOW(x) (0x371 + (x) * 2)  /* 8 bit */
 
-#define NCT6687_REG_FAN_MIN(x) (0x3b8 + (x)*2) /* 16 bit */
+#define NCT6687_REG_FAN_MIN(x) (0x3b8 + (x) * 2) /* 16 bit */
 
 #define NCT6687_REG_FAN_CTRL_MODE(x) 0xA00
 #define NCT6687_REG_FAN_PWM_COMMAND(x) 0xA01
-#define NCT6687_FAN_CFG_REQ  0x80
+#define NCT6687_FAN_CFG_REQ 0x80
 #define NCT6687_FAN_CFG_DONE 0x40
 
-#define NCT6687_REG_FAN_ENGINE_STS          0xCF8    /* 8 bit */
-#define NCT6687_FAN_PECI_CFG_ADJUSTED       (1 << 1)
-#define NCT6687_FAN_UNFINISHED_FLAG         (1 << 2)
-#define NCT6687_FAN_CFG_PHASE               (1 << 3)
-#define NCT6687_FAN_CFG_INVALID             (1 << 4)
-#define NCT6687_FAN_CFG_CHECK_DONE          (1 << 5)
-#define NCT6687_FAN_CFG_LOCK                (1 << 6)
-#define NCT6687_FAN_DRIVE_BY_MOD_SEL        (0 << 7)
-#define NCT6687_FAN_DRIVE_BY_DEFAULT_VAL    (1 << 7)
+#define NCT6687_REG_FAN_ENGINE_STS 0xCF8 /* 8 bit */
+#define NCT6687_FAN_PECI_CFG_ADJUSTED (1 << 1)
+#define NCT6687_FAN_UNFINISHED_FLAG (1 << 2)
+#define NCT6687_FAN_CFG_PHASE (1 << 3)
+#define NCT6687_FAN_CFG_INVALID (1 << 4)
+#define NCT6687_FAN_CFG_CHECK_DONE (1 << 5)
+#define NCT6687_FAN_CFG_LOCK (1 << 6)
+#define NCT6687_FAN_DRIVE_BY_MOD_SEL (0 << 7)
+#define NCT6687_FAN_DRIVE_BY_DEFAULT_VAL (1 << 7)
 
 #define NCT6687_REG_BUILD_YEAR 0x604
 #define NCT6687_REG_BUILD_MONTH 0x605
@@ -346,107 +347,100 @@ struct nct6687_fan_config
 {
 	u16 reg_rpm;
 	u16 reg_pwm;
-	u16 reg_pwm_write;  // PWM write/control register
+	u16 reg_pwm_write; // PWM write/control register
 	const char *label;
 };
 
 static struct nct6687_fan_config nct6687_fan_config_default[] = {
-	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"}, 		 // CPU Fan
-	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"}, 	 // PUMP Fan
-	{ .reg_rpm = 0x144, .reg_pwm = 0x162, .reg_pwm_write = 0xA2A, .label = "System Fan #1"}, // SYS Fan 1, Nil on others
-	{ .reg_rpm = 0x146, .reg_pwm = 0x163, .reg_pwm_write = 0xA2B, .label = "System Fan #2"}, // SYS Fan 2, EZConn on others
-	{ .reg_rpm = 0x148, .reg_pwm = 0x164, .reg_pwm_write = 0xA2C, .label = "System Fan #3"}, // SYS Fan 3
-	{ .reg_rpm = 0x14A, .reg_pwm = 0x165, .reg_pwm_write = 0xA2D, .label = "System Fan #4"}, // SYS Fan 4
-	{ .reg_rpm = 0x14C, .reg_pwm = 0x166, .reg_pwm_write = 0xA2E, .label = "System Fan #5"}, // SYS Fan 5
-	{ .reg_rpm = 0x14E, .reg_pwm = 0x167, .reg_pwm_write = 0xA2F, .label = "System Fan #6"}, // SYS Fan 6
+	{.reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},		// CPU Fan
+	{.reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},		// PUMP Fan
+	{.reg_rpm = 0x144, .reg_pwm = 0x162, .reg_pwm_write = 0xA2A, .label = "System Fan #1"}, // SYS Fan 1, Nil on others
+	{.reg_rpm = 0x146, .reg_pwm = 0x163, .reg_pwm_write = 0xA2B, .label = "System Fan #2"}, // SYS Fan 2, EZConn on others
+	{.reg_rpm = 0x148, .reg_pwm = 0x164, .reg_pwm_write = 0xA2C, .label = "System Fan #3"}, // SYS Fan 3
+	{.reg_rpm = 0x14A, .reg_pwm = 0x165, .reg_pwm_write = 0xA2D, .label = "System Fan #4"}, // SYS Fan 4
+	{.reg_rpm = 0x14C, .reg_pwm = 0x166, .reg_pwm_write = 0xA2E, .label = "System Fan #5"}, // SYS Fan 5
+	{.reg_rpm = 0x14E, .reg_pwm = 0x167, .reg_pwm_write = 0xA2F, .label = "System Fan #6"}, // SYS Fan 6
 };
 
-//some MSI B850, X870, and Z890 boards
-//PWM registers and control registers from LibreHardwareMonitor NCT6687DR (current master)
-//https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+// some MSI B850, X870, and Z890 boards
+// PWM registers and control registers from LibreHardwareMonitor (NCT6687D with alternative mapping)
+// https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
 static struct nct6687_fan_config nct6687_fan_config_msi_alt[] = {
-	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},
-	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},
-	{ .reg_rpm = 0x15E, .reg_pwm = 0xE05, .reg_pwm_write = 0xC70, .label = "System Fan #1"},
-	{ .reg_rpm = 0x15C, .reg_pwm = 0xE04, .reg_pwm_write = 0xC58, .label = "System Fan #2"},
-	{ .reg_rpm = 0x15A, .reg_pwm = 0xE03, .reg_pwm_write = 0xC40, .label = "System Fan #3"},
-	{ .reg_rpm = 0x158, .reg_pwm = 0xE02, .reg_pwm_write = 0xC28, .label = "System Fan #4"},
-	{ .reg_rpm = 0x156, .reg_pwm = 0xE01, .reg_pwm_write = 0xC10, .label = "System Fan #5"},
-	{ .reg_rpm = 0x154, .reg_pwm = 0xE00, .reg_pwm_write = 0xBF8, .label = "System Fan #6"},
+	{.reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},
+	{.reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},
+	{.reg_rpm = 0x15E, .reg_pwm = 0xE05, .reg_pwm_write = 0xC70, .label = "System Fan #1"},
+	{.reg_rpm = 0x15C, .reg_pwm = 0xE04, .reg_pwm_write = 0xC58, .label = "System Fan #2"},
+	{.reg_rpm = 0x15A, .reg_pwm = 0xE03, .reg_pwm_write = 0xC40, .label = "System Fan #3"},
+	{.reg_rpm = 0x158, .reg_pwm = 0xE02, .reg_pwm_write = 0xC28, .label = "System Fan #4"},
+	{.reg_rpm = 0x156, .reg_pwm = 0xE01, .reg_pwm_write = 0xC10, .label = "System Fan #5"},
+	{.reg_rpm = 0x154, .reg_pwm = 0xE00, .reg_pwm_write = 0xBF8, .label = "System Fan #6"},
 };
 
-enum nct6687_fan_config_type {
+enum nct6687_fan_config_type
+{
 	FAN_CONFIG_DEFAULT = 0,
-	FAN_CONFIG_MSI_ALT1, //some MSI B850, X870, and Z890 boards
+	FAN_CONFIG_MSI_ALT1, // some MSI B850, X870, and Z890 boards
 };
 
 /*
  * MSI boards that require fan_config=msi_alt1 for proper system fan control
  * These boards use different PWM control registers and require 7-point fan curve writes
- * 
- * Based on LibreHardwareMonitor NCT6687DR implementation:
+ *
+ * Board names with MS-7Exx codes are unique enough - no vendor match needed.
+ *
+ * Based on LibreHardwareMonitor implementation:
  * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/commit/a55a7a772e5fee7a91f277b01032dc1e8a225e7c
  */
 static const struct dmi_system_id nct6687_msi_alt_boards[] __initconst = {
 	{
 		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Micro-Star International Co., Ltd."),
 			DMI_MATCH(DMI_BOARD_NAME, "MAG Z890 TOMAHAWK WIFI (MS-7E32)"),
 		},
 	},
 	{
 		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Micro-Star International Co., Ltd. "),
 			DMI_MATCH(DMI_BOARD_NAME, "MAG X870E TOMAHAWK WIFI (MS-7E26)"),
 		},
 	},
 	{
 		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Micro-Star International Co., Ltd."),
 			DMI_MATCH(DMI_BOARD_NAME, "MPG X870E CARBON WIFI (MS-7E27)"),
 		},
 	},
 	{
 		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Micro-Star International Co., Ltd."),
 			DMI_MATCH(DMI_BOARD_NAME, "MAG B850M MORTAR WIFI (MS-7E28)"),
 		},
 	},
 	{
 		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Micro-Star International Co., Ltd."),
 			DMI_MATCH(DMI_BOARD_NAME, "MEG Z890 ACE (MS-7E29)"),
 		},
 	},
 	{
 		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Micro-Star International Co., Ltd."),
 			DMI_MATCH(DMI_BOARD_NAME, "MPG Z890 CARBON WIFI (MS-7E30)"),
 		},
 	},
 	{
 		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Micro-Star International Co., Ltd."),
 			DMI_MATCH(DMI_BOARD_NAME, "PRO Z890-A WIFI (MS-7E34)"),
 		},
 	},
 	{
-		. matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Micro-Star International Co., Ltd."),
+		.matches = {
 			DMI_MATCH(DMI_BOARD_NAME, "MPG B850 EDGE TI WIFI (MS-7E35)"),
 		},
 	},
 	{
 		.matches = {
-			DMI_MATCH(DMI_BOARD_VENDOR, "Micro-Star International Co., Ltd."),
 			DMI_MATCH(DMI_BOARD_NAME, "PRO X870-P WIFI (MS-7E36)"),
 		},
 	},
-	{ }
-};
+	{}};
 
 static int nct6687_fan_config_type = FAN_CONFIG_DEFAULT; // default
-static struct nct6687_fan_config (*nct6687_fan_config_active) = nct6687_fan_config_default;
+static struct nct6687_fan_config(*nct6687_fan_config_active) = nct6687_fan_config_default;
 
 static int nct6687_fan_config_op_write_handler(const char *val, const struct kernel_param *kp)
 {
@@ -458,13 +452,18 @@ static int nct6687_fan_config_op_write_handler(const char *val, const struct ker
 
 	s = strstrip(valcp);
 
-	if (strcmp(s, "default") == 0) {
+	if (strcmp(s, "default") == 0)
+	{
 		nct6687_fan_config_type = FAN_CONFIG_DEFAULT;
 		nct6687_fan_config_active = nct6687_fan_config_default;
-	} else if (strcmp(s, "msi_alt1") == 0) {
+	}
+	else if (strcmp(s, "msi_alt1") == 0)
+	{
 		nct6687_fan_config_type = FAN_CONFIG_MSI_ALT1;
 		nct6687_fan_config_active = nct6687_fan_config_msi_alt;
-	} else {
+	}
+	else
+	{
 		return -EINVAL;
 	}
 
@@ -473,18 +472,19 @@ static int nct6687_fan_config_op_write_handler(const char *val, const struct ker
 
 static int nct6687_fan_config_op_read_handler(char *buffer, const struct kernel_param *kp)
 {
-	switch (nct6687_fan_config_type) {
-		case FAN_CONFIG_DEFAULT:
-			strcpy(buffer, "default");
-			break;
+	switch (nct6687_fan_config_type)
+	{
+	case FAN_CONFIG_DEFAULT:
+		strcpy(buffer, "default");
+		break;
 
-		case FAN_CONFIG_MSI_ALT1:
-			strcpy(buffer, "msi_alt1");
-			break;
+	case FAN_CONFIG_MSI_ALT1:
+		strcpy(buffer, "msi_alt1");
+		break;
 
-		default:
-			strcpy(buffer, "error");
-			break;
+	default:
+		strcpy(buffer, "error");
+		break;
 	}
 
 	return strlen(buffer);
@@ -492,8 +492,7 @@ static int nct6687_fan_config_op_read_handler(char *buffer, const struct kernel_
 
 static const struct kernel_param_ops nct6687_fan_config_op_ops = {
 	.set = nct6687_fan_config_op_write_handler,
-	.get = nct6687_fan_config_op_read_handler
-};
+	.get = nct6687_fan_config_op_read_handler};
 
 module_param_cb(fan_config, &nct6687_fan_config_op_ops, NULL, 0660);
 
@@ -573,8 +572,7 @@ struct sensor_device_attr_u
 	{                                                                   \
 		.dev_attr = __TEMPLATE_ATTR(_template, _mode, _show, _store),   \
 		.u.index = _index,                                              \
-		.s2 = false                                                     \
-	}
+		.s2 = false}
 
 #define SENSOR_DEVICE_TEMPLATE_2(_template, _mode, _show, _store,     \
 								 _nr, _index)                         \
@@ -582,8 +580,7 @@ struct sensor_device_attr_u
 		.dev_attr = __TEMPLATE_ATTR(_template, _mode, _show, _store), \
 		.u.s.index = _index,                                          \
 		.u.s.nr = _nr,                                                \
-		.s2 = true                                                    \
-	}
+		.s2 = true}
 
 #define SENSOR_TEMPLATE(_name, _template, _mode, _show, _store, _index)                                                        \
 	static struct sensor_device_template sensor_dev_template_##_name = SENSOR_DEVICE_TEMPLATE(_template, _mode, _show, _store, \
@@ -603,7 +600,7 @@ struct sensor_template_group
 
 static void nct6687_save_fan_control(struct nct6687_data *data, int index);
 
-static const char* nct6687_voltage_label(char* buf, int index)
+static const char *nct6687_voltage_label(char *buf, int index)
 {
 	if (manual)
 		sprintf(buf, "in%d", index);
@@ -723,10 +720,10 @@ static void nct6687_write(struct nct6687_data *data, u16 address, u16 value)
 /*
  * Write PWM value to all points of the fan curve.
  *
- * On MSI boards with NCT6687DR, system fans (index >= 2) only respond
+ * On some MSI boards with NCT6687D, system fans (index >= 2) only respond
  * to changes in the fan curve registers, not to direct PWM writes.
  *
- * This "brute force" method writes the same value to the first register
+ * This "brute force" method writes the same value to both registers
  * of all 7 curve points, effectively creating a flat curve where the fan
  * runs at constant speed regardless of temperature.
  *
@@ -735,12 +732,11 @@ static void nct6687_write(struct nct6687_data *data, u16 address, u16 value)
  */
 static void nct6687_write_all_curve(struct nct6687_data *data, u16 base_address, u8 value)
 {
-	for (int i = 0; i < NCT6687_FAN_CURVE_POINTS; i++)
+	int i;
+	// Write 7-point fan curve (14 registers total: 7 points × 2 registers per point)
+	for (i = 0; i < NCT6687_FAN_CURVE_POINTS * NCT6687_FAN_CURVE_POINT_SIZE; i++)
 	{
-		u16 point_address = base_address + (i * NCT6687_FAN_CURVE_POINT_SIZE);
-		nct6687_write(data, point_address, value);
-		// Note: We only write to register0 of each point.
-		// register1 purpose is unclear and left unchanged.
+		nct6687_write(data, base_address + i, value);
 	}
 }
 
@@ -995,20 +991,23 @@ static bool start_fan_cfg_update(struct nct6687_data *data, int fan)
 	u8 engsts;
 
 	engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
-	if (!(engsts & NCT6687_FAN_CFG_LOCK) && (engsts & NCT6687_FAN_CFG_PHASE)) {
+	if (!(engsts & NCT6687_FAN_CFG_LOCK) && (engsts & NCT6687_FAN_CFG_PHASE))
+	{
 		pr_warn("Fan registers are already accessible\n");
 		return true;
 	}
 
 	/* Wait up to a second until config phase is done and config request is clear. */
-	for (i = 0; i < 1000; i++) {
+	for (i = 0; i < 1000; i++)
+	{
 		if (!(nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS) & NCT6687_FAN_CFG_PHASE) &&
-		    !(nct6687_read(data, NCT6687_REG_FAN_PWM_COMMAND(fan)) & NCT6687_FAN_CFG_REQ))
+			!(nct6687_read(data, NCT6687_REG_FAN_PWM_COMMAND(fan)) & NCT6687_FAN_CFG_REQ))
 			break;
 		msleep(1);
 	}
 
-	if (i == 1000) {
+	if (i == 1000)
+	{
 		pr_err("EC is stuck in configuration phase for too long\n");
 		return false;
 	}
@@ -1016,14 +1015,16 @@ static bool start_fan_cfg_update(struct nct6687_data *data, int fan)
 	nct6687_write(data, NCT6687_REG_FAN_PWM_COMMAND(fan), NCT6687_FAN_CFG_REQ);
 
 	/* Wait up to a second until EC enters config phase and unlocks the register set. */
-	for (i = 0; i < 1000; i++) {
-	    engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
+	for (i = 0; i < 1000; i++)
+	{
+		engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
 		if (!(engsts & NCT6687_FAN_CFG_LOCK) && (engsts & NCT6687_FAN_CFG_PHASE))
 			break;
 		msleep(1);
 	}
 
-	if (i == 1000) {
+	if (i == 1000)
+	{
 		pr_err("Failed to gain access to fan configuration registers\n");
 		return false;
 	}
@@ -1038,7 +1039,8 @@ static void finish_fan_cfg_update(struct nct6687_data *data, int fan)
 	u8 donecmd;
 
 	engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
-	if ((engsts & NCT6687_FAN_CFG_LOCK) || !(engsts & NCT6687_FAN_CFG_PHASE)) {
+	if ((engsts & NCT6687_FAN_CFG_LOCK) || !(engsts & NCT6687_FAN_CFG_PHASE))
+	{
 		pr_warn("Fan registers are already not accessible\n");
 		return;
 	}
@@ -1054,7 +1056,8 @@ static void finish_fan_cfg_update(struct nct6687_data *data, int fan)
 	nct6687_write(data, NCT6687_REG_FAN_PWM_COMMAND(fan), donecmd);
 
 	/* Wait up to a second until EC checks new configuration. */
-	for (i = 0; i < 1000; i++) {
+	for (i = 0; i < 1000; i++)
+	{
 		engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
 		if (engsts & NCT6687_FAN_CFG_CHECK_DONE)
 			break;
@@ -1097,7 +1100,12 @@ static ssize_t store_pwm(struct device *dev, struct device_attribute *attr, cons
 	{
 		if (index >= NCT6687_FIRST_SYSTEM_FAN_INDEX && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_fan_brute_force)
 		{
-			nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), val);
+			// For MSI alt boards: Check if current PWM already matches target to avoid unnecessary writes
+			u8 current_pwm = nct6687_read(data, NCT6687_REG_PWM(index));
+			if (current_pwm != val)
+			{
+				nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), val);
+			}
 		}
 		else
 		{
@@ -1320,11 +1328,11 @@ static void nct6687_setup_pwm(struct nct6687_data *data)
 		data->pwm_enable[i] = nct6687_get_pwm_enable(data, i);
 
 		pr_debug("nct6687_setup_pwm[%d], addr=%04X, pwm=%d, pwm_enable=%d, _initialFanPwmCommand=%d\n",
-		         i,
-		         NCT6687_REG_FAN_PWM_COMMAND(i),
-		         data->pwm[i],
-		         data->pwm_enable[i],
-		         data->_initialFanPwmCommand[i]);
+				 i,
+				 NCT6687_REG_FAN_PWM_COMMAND(i),
+				 data->pwm[i],
+				 data->pwm_enable[i],
+				 data->_initialFanPwmCommand[i]);
 	}
 }
 
@@ -1368,6 +1376,14 @@ static int nct6687_probe(struct platform_device *pdev)
 	data->kind = sio_data->kind;
 	data->sioreg = sio_data->sioreg;
 	data->addr = res->start;
+
+	// Auto-detect MSI boards requiring alternative fan configuration
+	if (data->kind == nct6687 && dmi_check_system(nct6687_msi_alt_boards))
+	{
+		nct6687_fan_config_type = FAN_CONFIG_MSI_ALT1;
+		nct6687_fan_config_active = nct6687_fan_config_msi_alt;
+		dev_info(dev, "Detected MSI board; using alternative fan configuration\n");
+	}
 
 	pr_debug("nct6687_probe addr=0x%04X, sioreg=0x%04X\n", data->addr, data->sioreg);
 
@@ -1485,26 +1501,28 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 
 	pr_debug("found chip ID: 0x%04x\n", val);
 
-       switch (val & SIO_ID_MASK) {
-        case SIO_NCT6683_ID:
-                sio_data->kind = nct6683;
-                break;
-        case SIO_NCT6686_ID:
-                sio_data->kind = nct6686;
-                break;
-        case SIO_NCT6687D_ID:
-        case SIO_NCT6687_ID:
-                sio_data->kind = nct6687;
-                break;
-        default:
-		if (force){
-                 sio_data->kind = nct6687;
-                 break;
+	switch (val & SIO_ID_MASK)
+	{
+	case SIO_NCT6683_ID:
+		sio_data->kind = nct6683;
+		break;
+	case SIO_NCT6686_ID:
+		sio_data->kind = nct6686;
+		break;
+	case SIO_NCT6687D_ID:
+	case SIO_NCT6687_ID:
+		sio_data->kind = nct6687;
+		break;
+	default:
+		if (force)
+		{
+			sio_data->kind = nct6687;
+			break;
 		}
-                if (val != 0xffff)
-                        pr_debug("unsupported chip ID: 0x%04x\n", val);
-                goto fail;
-        }
+		if (val != 0xffff)
+			pr_debug("unsupported chip ID: 0x%04x\n", val);
+		goto fail;
+	}
 
 	/* We have a known chip, find the HWM I/O address */
 	superio_select(sioaddr, NCT6687_LD_HWM);
@@ -1564,8 +1582,10 @@ static int __init sensors_nct6687_init(void)
 	int i, err;
 
 	/* Auto-detect MSI boards that require msi_alt1 configuration */
-	if (nct6687_fan_config_type == FAN_CONFIG_DEFAULT) {
-		if (dmi_check_system(nct6687_msi_alt_boards)) {
+	if (nct6687_fan_config_type == FAN_CONFIG_DEFAULT)
+	{
+		if (dmi_check_system(nct6687_msi_alt_boards))
+		{
 			pr_info("Detected MSI board requiring msi_alt1 fan configuration\n");
 			nct6687_fan_config_type = FAN_CONFIG_MSI_ALT1;
 			nct6687_fan_config_active = nct6687_fan_config_msi_alt;

--- a/nct6687.c
+++ b/nct6687.c
@@ -1387,7 +1387,8 @@ static int nct6687_probe(struct platform_device *pdev)
 	{
 		nct6687_fan_config_type = FAN_CONFIG_MSI_ALT1;
 		nct6687_fan_config_active = nct6687_fan_config_msi_alt;
-		dev_info(dev, "Detected MSI board with msi_fan_brute_force %s\n",
+		dev_info(dev, "Detected MSI board; using alternative fan configuration (msi_alt1)\n");
+		dev_info(dev, "MSI fan brute force mode: %s\n",
 				 msi_fan_brute_force ? "enabled" : "disabled");
 	}
 

--- a/nct6687.c
+++ b/nct6687.c
@@ -1386,7 +1386,8 @@ static int nct6687_probe(struct platform_device *pdev)
 	{
 		nct6687_fan_config_type = FAN_CONFIG_MSI_ALT1;
 		nct6687_fan_config_active = nct6687_fan_config_msi_alt;
-		dev_info(dev, "Detected MSI board; using alternative fan configuration\n");
+		dev_info(dev, "Detected MSI board with msi_fan_brute_force %s\n",
+				 msi_fan_brute_force ? "enabled" : "disabled");
 	}
 
 	pr_debug("nct6687_probe addr=0x%04X, sioreg=0x%04X\n", data->addr, data->sioreg);

--- a/nct6687.c
+++ b/nct6687.c
@@ -7,10 +7,10 @@
  *
  * Derived from nct6683 driver
  * Copyright (C) 2013  Guenter Roeck <linux@roeck-us.net>
- * 
+ *
  * Inspired of LibreHardwareMonitor
  * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor
- * 
+ *
  * Supports the following chips:
  *
  * Chip       #voltage   #fan    #pwm    #temp  chip ID
@@ -38,11 +38,11 @@
 #include <linux/slab.h>
 
 #ifndef MIN
-#define MIN(a,b) (((a)<(b))?(a):(b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
 #ifndef MAX
-#define MAX(a,b) (((a)>(b))?(a):(b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif
 
 #define NCT6687_FAN_CURVE_POINTS 7 // Number of points in the fan curve registers
@@ -63,12 +63,16 @@ enum pwm_enable
 
 static bool force;
 static bool manual;
+static bool msi_btf;
 
 module_param(force, bool, 0);
 MODULE_PARM_DESC(force, "Set to one to enable support for unknown vendors");
 
 module_param(manual, bool, 0);
 MODULE_PARM_DESC(manual, "Set voltage input and voltage label configured with external sensors file");
+
+module_param(msi_btf, bool, 0);
+MODULE_PARM_DESC(msi_btf, "Enable brute force fan curve writing (write to all 7 curve points)");
 
 static const char *const nct6687_device_names[] = {
 	"nct6683",
@@ -98,12 +102,12 @@ static const char *const nct6687_chip_names[] = {
 #define SIO_REG_ENABLE 0x30		 /* Logical device enable */
 #define SIO_REG_ADDR 0x60		 /* Logical device address (2 bytes) */
 
-#define SIO_NCT6681_ID          0xb270  /* for later */
-#define SIO_NCT6683_ID          0xc730
-#define SIO_NCT6686_ID          0xd440
-#define SIO_NCT6687D_ID         0xd450  /* NCT6687 ???*/
-#define SIO_NCT6687_ID          0xd590
-#define SIO_ID_MASK             0xFFF0
+#define SIO_NCT6681_ID 0xb270 /* for later */
+#define SIO_NCT6683_ID 0xc730
+#define SIO_NCT6686_ID 0xd440
+#define SIO_NCT6687D_ID 0xd450 /* NCT6687 ???*/
+#define SIO_NCT6687_ID 0xd590
+#define SIO_ID_MASK 0xFFF0
 
 static inline void superio_outb(int ioreg, int reg, int val)
 {
@@ -161,8 +165,8 @@ static inline void superio_exit(int ioreg)
 #define NCT6687_NUM_REG_FAN 8
 #define NCT6687_NUM_REG_PWM 8
 
-#define NCT6687_REG_TEMP(x) (0x100 + (x)*2)
-#define NCT6687_REG_VOLTAGE(x) (0x120 + (x)*2)
+#define NCT6687_REG_TEMP(x) (0x100 + (x) * 2)
+#define NCT6687_REG_VOLTAGE(x) (0x120 + (x) * 2)
 #define NCT6687_REG_FAN_RPM(x) (nct6687_fan_config_active[x].reg_rpm)
 #define NCT6687_REG_PWM(x) (nct6687_fan_config_active[x].reg_pwm)
 #define NCT6687_REG_PWM_WRITE(x) (nct6687_fan_config_active[x].reg_pwm_write)
@@ -173,27 +177,27 @@ static inline void superio_exit(int ioreg)
 #define NCT6687_REG_FANIN_CFG(x) (0xA00 + (x))
 #define NCT6687_REG_FANOUT_CFG(x) (0x1d0 + (x))
 
-#define NCT6687_REG_TEMP_HYST(x) (0x330 + (x))	/* 8 bit */
-#define NCT6687_REG_TEMP_MAX(x) (0x350 + (x))	/* 8 bit */
-#define NCT6687_REG_MON_HIGH(x) (0x370 + (x)*2) /* 8 bit */
-#define NCT6687_REG_MON_LOW(x) (0x371 + (x)*2)	/* 8 bit */
+#define NCT6687_REG_TEMP_HYST(x) (0x330 + (x))	  /* 8 bit */
+#define NCT6687_REG_TEMP_MAX(x) (0x350 + (x))	  /* 8 bit */
+#define NCT6687_REG_MON_HIGH(x) (0x370 + (x) * 2) /* 8 bit */
+#define NCT6687_REG_MON_LOW(x) (0x371 + (x) * 2)  /* 8 bit */
 
-#define NCT6687_REG_FAN_MIN(x) (0x3b8 + (x)*2) /* 16 bit */
+#define NCT6687_REG_FAN_MIN(x) (0x3b8 + (x) * 2) /* 16 bit */
 
 #define NCT6687_REG_FAN_CTRL_MODE(x) 0xA00
 #define NCT6687_REG_FAN_PWM_COMMAND(x) 0xA01
-#define NCT6687_FAN_CFG_REQ  0x80
+#define NCT6687_FAN_CFG_REQ 0x80
 #define NCT6687_FAN_CFG_DONE 0x40
 
-#define NCT6687_REG_FAN_ENGINE_STS          0xCF8    /* 8 bit */
-#define   NCT6687_FAN_PECI_CFG_ADJUSTED     (1 << 1)
-#define   NCT6687_FAN_UNFINISHED_FLAG       (1 << 2)
-#define   NCT6687_FAN_CFG_PHASE             (1 << 3)
-#define   NCT6687_FAN_CFG_INVALID           (1 << 4)
-#define   NCT6687_FAN_CFG_CHECK_DONE        (1 << 5)
-#define   NCT6687_FAN_CFG_LOCK              (1 << 6)
-#define   NCT6687_FAN_DRIVE_BY_MOD_SEL      (0 << 7)
-#define   NCT6687_FAN_DRIVE_BY_DEFAULT_VAL  (1 << 7)
+#define NCT6687_REG_FAN_ENGINE_STS 0xCF8 /* 8 bit */
+#define NCT6687_FAN_PECI_CFG_ADJUSTED (1 << 1)
+#define NCT6687_FAN_UNFINISHED_FLAG (1 << 2)
+#define NCT6687_FAN_CFG_PHASE (1 << 3)
+#define NCT6687_FAN_CFG_INVALID (1 << 4)
+#define NCT6687_FAN_CFG_CHECK_DONE (1 << 5)
+#define NCT6687_FAN_CFG_LOCK (1 << 6)
+#define NCT6687_FAN_DRIVE_BY_MOD_SEL (0 << 7)
+#define NCT6687_FAN_DRIVE_BY_DEFAULT_VAL (1 << 7)
 
 #define NCT6687_REG_BUILD_YEAR 0x604
 #define NCT6687_REG_BUILD_MONTH 0x605
@@ -324,42 +328,43 @@ struct nct6687_fan_config
 {
 	u16 reg_rpm;
 	u16 reg_pwm;
-	u16 reg_pwm_write;  // PWM write/control register
+	u16 reg_pwm_write; // PWM write/control register
 	const char *label;
 };
 
 static struct nct6687_fan_config nct6687_fan_config_default[] = {
-	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"}, // CPU Fan
-	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"}, // PUMP Fan
-	{ .reg_rpm = 0x144, .reg_pwm = 0x162, .reg_pwm_write = 0xA2A, .label = "System Fan #1"}, // SYS Fan 1, Nil on others
-	{ .reg_rpm = 0x146, .reg_pwm = 0x163, .reg_pwm_write = 0xA2B, .label = "System Fan #2"}, // SYS Fan 2, EZConn on others
-	{ .reg_rpm = 0x148, .reg_pwm = 0x164, .reg_pwm_write = 0xA2C, .label = "System Fan #3"}, // SYS Fan 3
-	{ .reg_rpm = 0x14A, .reg_pwm = 0x165, .reg_pwm_write = 0xA2D, .label = "System Fan #4"}, // SYS Fan 4
-	{ .reg_rpm = 0x14C, .reg_pwm = 0x166, .reg_pwm_write = 0xA2E, .label = "System Fan #5"}, // SYS Fan 5
-	{ .reg_rpm = 0x14E, .reg_pwm = 0x167, .reg_pwm_write = 0xA2F, .label = "System Fan #6"}, // SYS Fan 6
+	{.reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},		// CPU Fan
+	{.reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},		// PUMP Fan
+	{.reg_rpm = 0x144, .reg_pwm = 0x162, .reg_pwm_write = 0xA2A, .label = "System Fan #1"}, // SYS Fan 1, Nil on others
+	{.reg_rpm = 0x146, .reg_pwm = 0x163, .reg_pwm_write = 0xA2B, .label = "System Fan #2"}, // SYS Fan 2, EZConn on others
+	{.reg_rpm = 0x148, .reg_pwm = 0x164, .reg_pwm_write = 0xA2C, .label = "System Fan #3"}, // SYS Fan 3
+	{.reg_rpm = 0x14A, .reg_pwm = 0x165, .reg_pwm_write = 0xA2D, .label = "System Fan #4"}, // SYS Fan 4
+	{.reg_rpm = 0x14C, .reg_pwm = 0x166, .reg_pwm_write = 0xA2E, .label = "System Fan #5"}, // SYS Fan 5
+	{.reg_rpm = 0x14E, .reg_pwm = 0x167, .reg_pwm_write = 0xA2F, .label = "System Fan #6"}, // SYS Fan 6
 };
 
-//some MSI B850, X870, and Z890 boards
-//PWM registers and control registers from LibreHardwareMonitor NCT6687DR (current master)
-//https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+// some MSI B850, X870, and Z890 boards
+// PWM registers and control registers from LibreHardwareMonitor NCT6687DR (current master)
+// https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
 static struct nct6687_fan_config nct6687_fan_config_msi_alt[] = {
-	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},
-	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},
-	{ .reg_rpm = 0x15E, .reg_pwm = 0xE05, .reg_pwm_write = 0xC70, .label = "System Fan #1"},
-	{ .reg_rpm = 0x15C, .reg_pwm = 0xE04, .reg_pwm_write = 0xC58, .label = "System Fan #2"},
-	{ .reg_rpm = 0x15A, .reg_pwm = 0xE03, .reg_pwm_write = 0xC40, .label = "System Fan #3"},
-	{ .reg_rpm = 0x158, .reg_pwm = 0xE02, .reg_pwm_write = 0xC28, .label = "System Fan #4"},
-	{ .reg_rpm = 0x156, .reg_pwm = 0xE01, .reg_pwm_write = 0xC10, .label = "System Fan #5"},
-	{ .reg_rpm = 0x154, .reg_pwm = 0xE00, .reg_pwm_write = 0xBF8, .label = "System Fan #6"},
+	{.reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},
+	{.reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},
+	{.reg_rpm = 0x15E, .reg_pwm = 0xE05, .reg_pwm_write = 0xC70, .label = "System Fan #1"},
+	{.reg_rpm = 0x15C, .reg_pwm = 0xE04, .reg_pwm_write = 0xC58, .label = "System Fan #2"},
+	{.reg_rpm = 0x15A, .reg_pwm = 0xE03, .reg_pwm_write = 0xC40, .label = "System Fan #3"},
+	{.reg_rpm = 0x158, .reg_pwm = 0xE02, .reg_pwm_write = 0xC28, .label = "System Fan #4"},
+	{.reg_rpm = 0x156, .reg_pwm = 0xE01, .reg_pwm_write = 0xC10, .label = "System Fan #5"},
+	{.reg_rpm = 0x154, .reg_pwm = 0xE00, .reg_pwm_write = 0xBF8, .label = "System Fan #6"},
 };
 
-enum nct6687_fan_config_type {
+enum nct6687_fan_config_type
+{
 	FAN_CONFIG_DEFAULT = 0,
-	FAN_CONFIG_MSI_ALT1, //some MSI B850, X870, and Z890 boards
+	FAN_CONFIG_MSI_ALT1, // some MSI B850, X870, and Z890 boards
 };
 
 static int nct6687_fan_config_type = FAN_CONFIG_DEFAULT; // default
-static struct nct6687_fan_config (*nct6687_fan_config_active) = nct6687_fan_config_default;
+static struct nct6687_fan_config(*nct6687_fan_config_active) = nct6687_fan_config_default;
 
 static int nct6687_fan_config_op_write_handler(const char *val, const struct kernel_param *kp)
 {
@@ -371,13 +376,18 @@ static int nct6687_fan_config_op_write_handler(const char *val, const struct ker
 
 	s = strstrip(valcp);
 
-	if (strcmp(s, "default") == 0) {
+	if (strcmp(s, "default") == 0)
+	{
 		nct6687_fan_config_type = FAN_CONFIG_DEFAULT;
 		nct6687_fan_config_active = nct6687_fan_config_default;
-	} else if (strcmp(s, "msi_alt1") == 0) {
+	}
+	else if (strcmp(s, "msi_alt1") == 0)
+	{
 		nct6687_fan_config_type = FAN_CONFIG_MSI_ALT1;
 		nct6687_fan_config_active = nct6687_fan_config_msi_alt;
-	} else {
+	}
+	else
+	{
 		return -EINVAL;
 	}
 
@@ -386,18 +396,19 @@ static int nct6687_fan_config_op_write_handler(const char *val, const struct ker
 
 static int nct6687_fan_config_op_read_handler(char *buffer, const struct kernel_param *kp)
 {
-	switch (nct6687_fan_config_type) {
-		case FAN_CONFIG_DEFAULT:
-			strcpy(buffer, "default");
-			break;
+	switch (nct6687_fan_config_type)
+	{
+	case FAN_CONFIG_DEFAULT:
+		strcpy(buffer, "default");
+		break;
 
-		case FAN_CONFIG_MSI_ALT1:
-			strcpy(buffer, "msi_alt1");
-			break;
+	case FAN_CONFIG_MSI_ALT1:
+		strcpy(buffer, "msi_alt1");
+		break;
 
-		default:
-			strcpy(buffer, "error");
-			break;
+	default:
+		strcpy(buffer, "error");
+		break;
 	}
 
 	return strlen(buffer);
@@ -405,8 +416,7 @@ static int nct6687_fan_config_op_read_handler(char *buffer, const struct kernel_
 
 static const struct kernel_param_ops nct6687_fan_config_op_ops = {
 	.set = nct6687_fan_config_op_write_handler,
-	.get = nct6687_fan_config_op_read_handler
-};
+	.get = nct6687_fan_config_op_read_handler};
 
 module_param_cb(fan_config, &nct6687_fan_config_op_ops, NULL, 0660);
 
@@ -486,8 +496,7 @@ struct sensor_device_attr_u
 	{                                                                   \
 		.dev_attr = __TEMPLATE_ATTR(_template, _mode, _show, _store),   \
 		.u.index = _index,                                              \
-		.s2 = false                                                     \
-	}
+		.s2 = false}
 
 #define SENSOR_DEVICE_TEMPLATE_2(_template, _mode, _show, _store,     \
 								 _nr, _index)                         \
@@ -495,8 +504,7 @@ struct sensor_device_attr_u
 		.dev_attr = __TEMPLATE_ATTR(_template, _mode, _show, _store), \
 		.u.s.index = _index,                                          \
 		.u.s.nr = _nr,                                                \
-		.s2 = true                                                    \
-	}
+		.s2 = true}
 
 #define SENSOR_TEMPLATE(_name, _template, _mode, _show, _store, _index)                                                        \
 	static struct sensor_device_template sensor_dev_template_##_name = SENSOR_DEVICE_TEMPLATE(_template, _mode, _show, _store, \
@@ -516,7 +524,7 @@ struct sensor_template_group
 
 static void nct6687_save_fan_control(struct nct6687_data *data, int index);
 
-static const char* nct6687_voltage_label(char* buf, int index)
+static const char *nct6687_voltage_label(char *buf, int index)
 {
 	if (manual)
 		sprintf(buf, "in%d", index);
@@ -635,12 +643,12 @@ static void nct6687_write(struct nct6687_data *data, u16 address, u16 value)
 
 /*
  * Write PWM value to all 7 points of the fan curve.
- * 
+ *
  * On MSI boards with NCT6687DR, system fans (index > 1) only respond
- * to changes in the fan curve registers, not to direct PWM writes. 
+ * to changes in the fan curve registers, not to direct PWM writes.
  * This "brute force" method sets a flat curve where all temperature
  * points result in the same fan speed.
- * 
+ *
  * Based on LibreHardwareMonitor implementation:
  * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/commit/a55a7a772e5fee7a91f277b01032dc1e8a225e7c
  */
@@ -904,20 +912,23 @@ static bool start_fan_cfg_update(struct nct6687_data *data, int fan)
 	u8 engsts;
 
 	engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
-	if (!(engsts & NCT6687_FAN_CFG_LOCK) && (engsts & NCT6687_FAN_CFG_PHASE)) {
+	if (!(engsts & NCT6687_FAN_CFG_LOCK) && (engsts & NCT6687_FAN_CFG_PHASE))
+	{
 		pr_warn("Fan registers are already accessible\n");
 		return true;
 	}
 
 	/* Wait up to a second until config phase is done and config request is clear. */
-	for (i = 0; i < 1000; i++) {
+	for (i = 0; i < 1000; i++)
+	{
 		if (!(nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS) & NCT6687_FAN_CFG_PHASE) &&
-		    !(nct6687_read(data, NCT6687_REG_FAN_PWM_COMMAND(fan)) & NCT6687_FAN_CFG_REQ))
+			!(nct6687_read(data, NCT6687_REG_FAN_PWM_COMMAND(fan)) & NCT6687_FAN_CFG_REQ))
 			break;
 		msleep(1);
 	}
 
-	if (i == 1000) {
+	if (i == 1000)
+	{
 		pr_err("EC is stuck in configuration phase for too long\n");
 		return false;
 	}
@@ -925,14 +936,16 @@ static bool start_fan_cfg_update(struct nct6687_data *data, int fan)
 	nct6687_write(data, NCT6687_REG_FAN_PWM_COMMAND(fan), NCT6687_FAN_CFG_REQ);
 
 	/* Wait up to a second until EC enters config phase and unlocks the register set. */
-	for (i = 0; i < 1000; i++) {
-	    engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
+	for (i = 0; i < 1000; i++)
+	{
+		engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
 		if (!(engsts & NCT6687_FAN_CFG_LOCK) && (engsts & NCT6687_FAN_CFG_PHASE))
 			break;
 		msleep(1);
 	}
 
-	if (i == 1000) {
+	if (i == 1000)
+	{
 		pr_err("Failed to gain access to fan configuration registers\n");
 		return false;
 	}
@@ -947,7 +960,8 @@ static void finish_fan_cfg_update(struct nct6687_data *data, int fan)
 	u8 donecmd;
 
 	engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
-	if ((engsts & NCT6687_FAN_CFG_LOCK) || !(engsts & NCT6687_FAN_CFG_PHASE)) {
+	if ((engsts & NCT6687_FAN_CFG_LOCK) || !(engsts & NCT6687_FAN_CFG_PHASE))
+	{
 		pr_warn("Fan registers are already not accessible\n");
 		return;
 	}
@@ -963,7 +977,8 @@ static void finish_fan_cfg_update(struct nct6687_data *data, int fan)
 	nct6687_write(data, NCT6687_REG_FAN_PWM_COMMAND(fan), donecmd);
 
 	/* Wait up to a second until EC checks new configuration. */
-	for (i = 0; i < 1000; i++) {
+	for (i = 0; i < 1000; i++)
+	{
 		engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
 		if (engsts & NCT6687_FAN_CFG_CHECK_DONE)
 			break;
@@ -1002,10 +1017,14 @@ static ssize_t store_pwm(struct device *dev, struct device_attribute *attr, cons
 	mode = (u8)(mode | bitMask);
 	nct6687_write(data, NCT6687_REG_FAN_CTRL_MODE(index), mode);
 
-	if (start_fan_cfg_update(data, index)) {
-		if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1) {
+	if (start_fan_cfg_update(data, index))
+	{
+		if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_btf)
+		{
 			nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), val);
-		} else {
+		}
+		else
+		{
 			nct6687_write(data, NCT6687_REG_PWM_WRITE(index), val);
 		}
 		finish_fan_cfg_update(data, index);
@@ -1092,10 +1111,14 @@ static void nct6687_restore_fan_control(struct nct6687_data *data, int index)
 
 		nct6687_write(data, NCT6687_REG_FAN_CTRL_MODE(index), mode);
 
-		if (start_fan_cfg_update(data, index)) {
-			if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1) {
+		if (start_fan_cfg_update(data, index))
+		{
+			if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_btf)
+			{
 				nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), data->_initialFanPwmCommand[index]);
-			} else {
+			}
+			else
+			{
 				nct6687_write(data, NCT6687_REG_PWM_WRITE(index), data->_initialFanPwmCommand[index]);
 			}
 			finish_fan_cfg_update(data, index);
@@ -1221,11 +1244,11 @@ static void nct6687_setup_pwm(struct nct6687_data *data)
 		data->pwm_enable[i] = nct6687_get_pwm_enable(data, i);
 
 		pr_debug("nct6687_setup_pwm[%d], addr=%04X, pwm=%d, pwm_enable=%d, _initialFanPwmCommand=%d\n",
-		         i,
-		         NCT6687_REG_FAN_PWM_COMMAND(i),
-		         data->pwm[i],
-		         data->pwm_enable[i],
-		         data->_initialFanPwmCommand[i]);
+				 i,
+				 NCT6687_REG_FAN_PWM_COMMAND(i),
+				 data->pwm[i],
+				 data->pwm_enable[i],
+				 data->_initialFanPwmCommand[i]);
 	}
 }
 
@@ -1386,26 +1409,28 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 
 	pr_debug("found chip ID: 0x%04x\n", val);
 
-       switch (val & SIO_ID_MASK) {
-        case SIO_NCT6683_ID:
-                sio_data->kind = nct6683;
-                break;
-        case SIO_NCT6686_ID:
-                sio_data->kind = nct6686;
-                break;
-        case SIO_NCT6687D_ID:
-        case SIO_NCT6687_ID:
-                sio_data->kind = nct6687;
-                break;
-        default:
-		if (force){
-                 sio_data->kind = nct6687;
-                 break;
+	switch (val & SIO_ID_MASK)
+	{
+	case SIO_NCT6683_ID:
+		sio_data->kind = nct6683;
+		break;
+	case SIO_NCT6686_ID:
+		sio_data->kind = nct6686;
+		break;
+	case SIO_NCT6687D_ID:
+	case SIO_NCT6687_ID:
+		sio_data->kind = nct6687;
+		break;
+	default:
+		if (force)
+		{
+			sio_data->kind = nct6687;
+			break;
 		}
-                if (val != 0xffff)
-                        pr_debug("unsupported chip ID: 0x%04x\n", val);
-                goto fail;
-        }
+		if (val != 0xffff)
+			pr_debug("unsupported chip ID: 0x%04x\n", val);
+		goto fail;
+	}
 
 	/* We have a known chip, find the HWM I/O address */
 	superio_select(sioaddr, NCT6687_LD_HWM);

--- a/nct6687.c
+++ b/nct6687.c
@@ -104,8 +104,6 @@ static const char *const nct6687_chip_names[] = {
 	"NCT6687D",
 };
 
-#define DRVNAME "nct6687"
-
 /*
  * Super-I/O constants and functions
  */

--- a/nct6687.c
+++ b/nct6687.c
@@ -37,8 +37,6 @@
 #include <linux/platform_device.h>
 #include <linux/slab.h>
 
-#define DRVNAME "nct6687"
-
 #ifndef MIN
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #endif
@@ -47,7 +45,7 @@
 #define MAX(a,b) (((a)>(b))?(a):(b))
 #endif
 
-#define NCT6687_FAN_CURVE_POINTS 7
+#define NCT6687_FAN_CURVE_POINTS 7 // Number of points in the fan curve registers
 
 enum kinds
 {

--- a/nct6687.c
+++ b/nct6687.c
@@ -49,6 +49,7 @@
 
 #define NCT6687_FAN_CURVE_POINTS 7 	   	// Number of points in the fan curve registers for each fan.
 #define NCT6687_FAN_CURVE_POINT_SIZE 2 	// Each curve point occupies 2 registers
+#define NCT6687_FIRST_SYSTEM_FAN_INDEX 2
 
 /*
  * Fan curve point structure.
@@ -206,14 +207,14 @@ static inline void superio_exit(int ioreg)
 #define NCT6687_FAN_CFG_DONE 0x40
 
 #define NCT6687_REG_FAN_ENGINE_STS          0xCF8    /* 8 bit */
-#define   NCT6687_FAN_PECI_CFG_ADJUSTED     (1 << 1)
-#define   NCT6687_FAN_UNFINISHED_FLAG       (1 << 2)
-#define   NCT6687_FAN_CFG_PHASE             (1 << 3)
-#define   NCT6687_FAN_CFG_INVALID           (1 << 4)
-#define   NCT6687_FAN_CFG_CHECK_DONE        (1 << 5)
-#define   NCT6687_FAN_CFG_LOCK              (1 << 6)
-#define   NCT6687_FAN_DRIVE_BY_MOD_SEL      (0 << 7)
-#define   NCT6687_FAN_DRIVE_BY_DEFAULT_VAL  (1 << 7)
+#define NCT6687_FAN_PECI_CFG_ADJUSTED       (1 << 1)
+#define NCT6687_FAN_UNFINISHED_FLAG         (1 << 2)
+#define NCT6687_FAN_CFG_PHASE               (1 << 3)
+#define NCT6687_FAN_CFG_INVALID             (1 << 4)
+#define NCT6687_FAN_CFG_CHECK_DONE          (1 << 5)
+#define NCT6687_FAN_CFG_LOCK                (1 << 6)
+#define NCT6687_FAN_DRIVE_BY_MOD_SEL        (0 << 7)
+#define NCT6687_FAN_DRIVE_BY_DEFAULT_VAL    (1 << 7)
 
 #define NCT6687_REG_BUILD_YEAR 0x604
 #define NCT6687_REG_BUILD_MONTH 0x605
@@ -656,7 +657,7 @@ static void nct6687_write(struct nct6687_data *data, u16 address, u16 value)
 /*
  * Write PWM value to all points of the fan curve.
  *
- * On MSI boards with NCT6687DR, system fans (index > 1) only respond
+ * On MSI boards with NCT6687DR, system fans (index >= 2) only respond
  * to changes in the fan curve registers, not to direct PWM writes.
  *
  * This "brute force" method writes the same value to the first register
@@ -1028,7 +1029,7 @@ static ssize_t store_pwm(struct device *dev, struct device_attribute *attr, cons
 
 	if (start_fan_cfg_update(data, index))
 	{
-		if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_fan_brute_force)
+		if (index >= NCT6687_FIRST_SYSTEM_FAN_INDEX && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_fan_brute_force)
 		{
 			nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), val);
 		}
@@ -1122,7 +1123,7 @@ static void nct6687_restore_fan_control(struct nct6687_data *data, int index)
 
 		if (start_fan_cfg_update(data, index))
 		{
-			if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_fan_brute_force)
+			if (index >= NCT6687_FIRST_SYSTEM_FAN_INDEX && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_fan_brute_force)
 			{
 				nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), data->_initialFanPwmCommand[index]);
 			}

--- a/nct6687.c
+++ b/nct6687.c
@@ -7,10 +7,10 @@
  *
  * Derived from nct6683 driver
  * Copyright (C) 2013  Guenter Roeck <linux@roeck-us.net>
- *
+ * 
  * Inspired of LibreHardwareMonitor
  * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor
- *
+ * 
  * Supports the following chips:
  *
  * Chip       #voltage   #fan    #pwm    #temp  chip ID
@@ -37,15 +37,18 @@
 #include <linux/platform_device.h>
 #include <linux/slab.h>
 
+#define DRVNAME "nct6687"
+
 #ifndef MIN
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define MIN(a,b) (((a)<(b))?(a):(b))
 #endif
 
 #ifndef MAX
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
 #endif
 
-#define NCT6687_FAN_CURVE_POINTS 7 // Number of points in the fan curve registers
+// Number of points in the fan curve registers for each fan.
+#define NCT6687_FAN_CURVE_POINTS 7
 
 enum kinds
 {
@@ -63,7 +66,7 @@ enum pwm_enable
 
 static bool force;
 static bool manual;
-static bool msi_btf;
+static bool msi_fan_brute_force; // Force use of alternative fan config for some MSI boards.
 
 module_param(force, bool, 0);
 MODULE_PARM_DESC(force, "Set to one to enable support for unknown vendors");
@@ -71,8 +74,8 @@ MODULE_PARM_DESC(force, "Set to one to enable support for unknown vendors");
 module_param(manual, bool, 0);
 MODULE_PARM_DESC(manual, "Set voltage input and voltage label configured with external sensors file");
 
-module_param(msi_btf, bool, 0);
-MODULE_PARM_DESC(msi_btf, "Enable brute force fan curve writing (write to all 7 curve points)");
+module_param(msi_fan_brute_force, bool, 0);
+MODULE_PARM_DESC(msi_fan_brute_force, "Enable brute force fan curve writing (write to all 7 curve points)");
 
 static const char *const nct6687_device_names[] = {
 	"nct6683",
@@ -102,12 +105,12 @@ static const char *const nct6687_chip_names[] = {
 #define SIO_REG_ENABLE 0x30		 /* Logical device enable */
 #define SIO_REG_ADDR 0x60		 /* Logical device address (2 bytes) */
 
-#define SIO_NCT6681_ID 0xb270 /* for later */
-#define SIO_NCT6683_ID 0xc730
-#define SIO_NCT6686_ID 0xd440
-#define SIO_NCT6687D_ID 0xd450 /* NCT6687 ???*/
-#define SIO_NCT6687_ID 0xd590
-#define SIO_ID_MASK 0xFFF0
+#define SIO_NCT6681_ID          0xb270  /* for later */
+#define SIO_NCT6683_ID          0xc730
+#define SIO_NCT6686_ID          0xd440
+#define SIO_NCT6687D_ID         0xd450  /* NCT6687 ???*/
+#define SIO_NCT6687_ID          0xd590
+#define SIO_ID_MASK             0xFFF0
 
 static inline void superio_outb(int ioreg, int reg, int val)
 {
@@ -165,8 +168,8 @@ static inline void superio_exit(int ioreg)
 #define NCT6687_NUM_REG_FAN 8
 #define NCT6687_NUM_REG_PWM 8
 
-#define NCT6687_REG_TEMP(x) (0x100 + (x) * 2)
-#define NCT6687_REG_VOLTAGE(x) (0x120 + (x) * 2)
+#define NCT6687_REG_TEMP(x) (0x100 + (x)*2)
+#define NCT6687_REG_VOLTAGE(x) (0x120 + (x)*2)
 #define NCT6687_REG_FAN_RPM(x) (nct6687_fan_config_active[x].reg_rpm)
 #define NCT6687_REG_PWM(x) (nct6687_fan_config_active[x].reg_pwm)
 #define NCT6687_REG_PWM_WRITE(x) (nct6687_fan_config_active[x].reg_pwm_write)
@@ -177,27 +180,27 @@ static inline void superio_exit(int ioreg)
 #define NCT6687_REG_FANIN_CFG(x) (0xA00 + (x))
 #define NCT6687_REG_FANOUT_CFG(x) (0x1d0 + (x))
 
-#define NCT6687_REG_TEMP_HYST(x) (0x330 + (x))	  /* 8 bit */
-#define NCT6687_REG_TEMP_MAX(x) (0x350 + (x))	  /* 8 bit */
-#define NCT6687_REG_MON_HIGH(x) (0x370 + (x) * 2) /* 8 bit */
-#define NCT6687_REG_MON_LOW(x) (0x371 + (x) * 2)  /* 8 bit */
+#define NCT6687_REG_TEMP_HYST(x) (0x330 + (x))	/* 8 bit */
+#define NCT6687_REG_TEMP_MAX(x) (0x350 + (x))	/* 8 bit */
+#define NCT6687_REG_MON_HIGH(x) (0x370 + (x)*2) /* 8 bit */
+#define NCT6687_REG_MON_LOW(x) (0x371 + (x)*2)	/* 8 bit */
 
-#define NCT6687_REG_FAN_MIN(x) (0x3b8 + (x) * 2) /* 16 bit */
+#define NCT6687_REG_FAN_MIN(x) (0x3b8 + (x)*2) /* 16 bit */
 
 #define NCT6687_REG_FAN_CTRL_MODE(x) 0xA00
 #define NCT6687_REG_FAN_PWM_COMMAND(x) 0xA01
-#define NCT6687_FAN_CFG_REQ 0x80
+#define NCT6687_FAN_CFG_REQ  0x80
 #define NCT6687_FAN_CFG_DONE 0x40
 
-#define NCT6687_REG_FAN_ENGINE_STS 0xCF8 /* 8 bit */
-#define NCT6687_FAN_PECI_CFG_ADJUSTED (1 << 1)
-#define NCT6687_FAN_UNFINISHED_FLAG (1 << 2)
-#define NCT6687_FAN_CFG_PHASE (1 << 3)
-#define NCT6687_FAN_CFG_INVALID (1 << 4)
-#define NCT6687_FAN_CFG_CHECK_DONE (1 << 5)
-#define NCT6687_FAN_CFG_LOCK (1 << 6)
-#define NCT6687_FAN_DRIVE_BY_MOD_SEL (0 << 7)
-#define NCT6687_FAN_DRIVE_BY_DEFAULT_VAL (1 << 7)
+#define NCT6687_REG_FAN_ENGINE_STS          0xCF8    /* 8 bit */
+#define   NCT6687_FAN_PECI_CFG_ADJUSTED     (1 << 1)
+#define   NCT6687_FAN_UNFINISHED_FLAG       (1 << 2)
+#define   NCT6687_FAN_CFG_PHASE             (1 << 3)
+#define   NCT6687_FAN_CFG_INVALID           (1 << 4)
+#define   NCT6687_FAN_CFG_CHECK_DONE        (1 << 5)
+#define   NCT6687_FAN_CFG_LOCK              (1 << 6)
+#define   NCT6687_FAN_DRIVE_BY_MOD_SEL      (0 << 7)
+#define   NCT6687_FAN_DRIVE_BY_DEFAULT_VAL  (1 << 7)
 
 #define NCT6687_REG_BUILD_YEAR 0x604
 #define NCT6687_REG_BUILD_MONTH 0x605
@@ -328,43 +331,42 @@ struct nct6687_fan_config
 {
 	u16 reg_rpm;
 	u16 reg_pwm;
-	u16 reg_pwm_write; // PWM write/control register
+	u16 reg_pwm_write;  // PWM write/control register
 	const char *label;
 };
 
 static struct nct6687_fan_config nct6687_fan_config_default[] = {
-	{.reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},		// CPU Fan
-	{.reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},		// PUMP Fan
-	{.reg_rpm = 0x144, .reg_pwm = 0x162, .reg_pwm_write = 0xA2A, .label = "System Fan #1"}, // SYS Fan 1, Nil on others
-	{.reg_rpm = 0x146, .reg_pwm = 0x163, .reg_pwm_write = 0xA2B, .label = "System Fan #2"}, // SYS Fan 2, EZConn on others
-	{.reg_rpm = 0x148, .reg_pwm = 0x164, .reg_pwm_write = 0xA2C, .label = "System Fan #3"}, // SYS Fan 3
-	{.reg_rpm = 0x14A, .reg_pwm = 0x165, .reg_pwm_write = 0xA2D, .label = "System Fan #4"}, // SYS Fan 4
-	{.reg_rpm = 0x14C, .reg_pwm = 0x166, .reg_pwm_write = 0xA2E, .label = "System Fan #5"}, // SYS Fan 5
-	{.reg_rpm = 0x14E, .reg_pwm = 0x167, .reg_pwm_write = 0xA2F, .label = "System Fan #6"}, // SYS Fan 6
+	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"}, 		 // CPU Fan
+	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"}, 	 // PUMP Fan
+	{ .reg_rpm = 0x144, .reg_pwm = 0x162, .reg_pwm_write = 0xA2A, .label = "System Fan #1"}, // SYS Fan 1, Nil on others
+	{ .reg_rpm = 0x146, .reg_pwm = 0x163, .reg_pwm_write = 0xA2B, .label = "System Fan #2"}, // SYS Fan 2, EZConn on others
+	{ .reg_rpm = 0x148, .reg_pwm = 0x164, .reg_pwm_write = 0xA2C, .label = "System Fan #3"}, // SYS Fan 3
+	{ .reg_rpm = 0x14A, .reg_pwm = 0x165, .reg_pwm_write = 0xA2D, .label = "System Fan #4"}, // SYS Fan 4
+	{ .reg_rpm = 0x14C, .reg_pwm = 0x166, .reg_pwm_write = 0xA2E, .label = "System Fan #5"}, // SYS Fan 5
+	{ .reg_rpm = 0x14E, .reg_pwm = 0x167, .reg_pwm_write = 0xA2F, .label = "System Fan #6"}, // SYS Fan 6
 };
 
-// some MSI B850, X870, and Z890 boards
-// PWM registers and control registers from LibreHardwareMonitor NCT6687DR (current master)
-// https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+//some MSI B850, X870, and Z890 boards
+//PWM registers and control registers from LibreHardwareMonitor NCT6687DR (current master)
+//https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
 static struct nct6687_fan_config nct6687_fan_config_msi_alt[] = {
-	{.reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},
-	{.reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},
-	{.reg_rpm = 0x15E, .reg_pwm = 0xE05, .reg_pwm_write = 0xC70, .label = "System Fan #1"},
-	{.reg_rpm = 0x15C, .reg_pwm = 0xE04, .reg_pwm_write = 0xC58, .label = "System Fan #2"},
-	{.reg_rpm = 0x15A, .reg_pwm = 0xE03, .reg_pwm_write = 0xC40, .label = "System Fan #3"},
-	{.reg_rpm = 0x158, .reg_pwm = 0xE02, .reg_pwm_write = 0xC28, .label = "System Fan #4"},
-	{.reg_rpm = 0x156, .reg_pwm = 0xE01, .reg_pwm_write = 0xC10, .label = "System Fan #5"},
-	{.reg_rpm = 0x154, .reg_pwm = 0xE00, .reg_pwm_write = 0xBF8, .label = "System Fan #6"},
+	{ .reg_rpm = 0x140, .reg_pwm = 0x160, .reg_pwm_write = 0xA28, .label = "CPU Fan"},
+	{ .reg_rpm = 0x142, .reg_pwm = 0x161, .reg_pwm_write = 0xA29, .label = "Pump Fan"},
+	{ .reg_rpm = 0x15E, .reg_pwm = 0xE05, .reg_pwm_write = 0xC70, .label = "System Fan #1"},
+	{ .reg_rpm = 0x15C, .reg_pwm = 0xE04, .reg_pwm_write = 0xC58, .label = "System Fan #2"},
+	{ .reg_rpm = 0x15A, .reg_pwm = 0xE03, .reg_pwm_write = 0xC40, .label = "System Fan #3"},
+	{ .reg_rpm = 0x158, .reg_pwm = 0xE02, .reg_pwm_write = 0xC28, .label = "System Fan #4"},
+	{ .reg_rpm = 0x156, .reg_pwm = 0xE01, .reg_pwm_write = 0xC10, .label = "System Fan #5"},
+	{ .reg_rpm = 0x154, .reg_pwm = 0xE00, .reg_pwm_write = 0xBF8, .label = "System Fan #6"},
 };
 
-enum nct6687_fan_config_type
-{
+enum nct6687_fan_config_type {
 	FAN_CONFIG_DEFAULT = 0,
-	FAN_CONFIG_MSI_ALT1, // some MSI B850, X870, and Z890 boards
+	FAN_CONFIG_MSI_ALT1, //some MSI B850, X870, and Z890 boards
 };
 
 static int nct6687_fan_config_type = FAN_CONFIG_DEFAULT; // default
-static struct nct6687_fan_config(*nct6687_fan_config_active) = nct6687_fan_config_default;
+static struct nct6687_fan_config (*nct6687_fan_config_active) = nct6687_fan_config_default;
 
 static int nct6687_fan_config_op_write_handler(const char *val, const struct kernel_param *kp)
 {
@@ -376,18 +378,13 @@ static int nct6687_fan_config_op_write_handler(const char *val, const struct ker
 
 	s = strstrip(valcp);
 
-	if (strcmp(s, "default") == 0)
-	{
+	if (strcmp(s, "default") == 0) {
 		nct6687_fan_config_type = FAN_CONFIG_DEFAULT;
 		nct6687_fan_config_active = nct6687_fan_config_default;
-	}
-	else if (strcmp(s, "msi_alt1") == 0)
-	{
+	} else if (strcmp(s, "msi_alt1") == 0) {
 		nct6687_fan_config_type = FAN_CONFIG_MSI_ALT1;
 		nct6687_fan_config_active = nct6687_fan_config_msi_alt;
-	}
-	else
-	{
+	} else {
 		return -EINVAL;
 	}
 
@@ -396,19 +393,18 @@ static int nct6687_fan_config_op_write_handler(const char *val, const struct ker
 
 static int nct6687_fan_config_op_read_handler(char *buffer, const struct kernel_param *kp)
 {
-	switch (nct6687_fan_config_type)
-	{
-	case FAN_CONFIG_DEFAULT:
-		strcpy(buffer, "default");
-		break;
+	switch (nct6687_fan_config_type) {
+		case FAN_CONFIG_DEFAULT:
+			strcpy(buffer, "default");
+			break;
 
-	case FAN_CONFIG_MSI_ALT1:
-		strcpy(buffer, "msi_alt1");
-		break;
+		case FAN_CONFIG_MSI_ALT1:
+			strcpy(buffer, "msi_alt1");
+			break;
 
-	default:
-		strcpy(buffer, "error");
-		break;
+		default:
+			strcpy(buffer, "error");
+			break;
 	}
 
 	return strlen(buffer);
@@ -416,7 +412,8 @@ static int nct6687_fan_config_op_read_handler(char *buffer, const struct kernel_
 
 static const struct kernel_param_ops nct6687_fan_config_op_ops = {
 	.set = nct6687_fan_config_op_write_handler,
-	.get = nct6687_fan_config_op_read_handler};
+	.get = nct6687_fan_config_op_read_handler
+};
 
 module_param_cb(fan_config, &nct6687_fan_config_op_ops, NULL, 0660);
 
@@ -496,7 +493,8 @@ struct sensor_device_attr_u
 	{                                                                   \
 		.dev_attr = __TEMPLATE_ATTR(_template, _mode, _show, _store),   \
 		.u.index = _index,                                              \
-		.s2 = false}
+		.s2 = false                                                     \
+	}
 
 #define SENSOR_DEVICE_TEMPLATE_2(_template, _mode, _show, _store,     \
 								 _nr, _index)                         \
@@ -504,7 +502,8 @@ struct sensor_device_attr_u
 		.dev_attr = __TEMPLATE_ATTR(_template, _mode, _show, _store), \
 		.u.s.index = _index,                                          \
 		.u.s.nr = _nr,                                                \
-		.s2 = true}
+		.s2 = true                                                    \
+	}
 
 #define SENSOR_TEMPLATE(_name, _template, _mode, _show, _store, _index)                                                        \
 	static struct sensor_device_template sensor_dev_template_##_name = SENSOR_DEVICE_TEMPLATE(_template, _mode, _show, _store, \
@@ -524,7 +523,7 @@ struct sensor_template_group
 
 static void nct6687_save_fan_control(struct nct6687_data *data, int index);
 
-static const char *nct6687_voltage_label(char *buf, int index)
+static const char* nct6687_voltage_label(char* buf, int index)
 {
 	if (manual)
 		sprintf(buf, "in%d", index);
@@ -643,12 +642,12 @@ static void nct6687_write(struct nct6687_data *data, u16 address, u16 value)
 
 /*
  * Write PWM value to all 7 points of the fan curve.
- *
+ * 
  * On MSI boards with NCT6687DR, system fans (index > 1) only respond
- * to changes in the fan curve registers, not to direct PWM writes.
+ * to changes in the fan curve registers, not to direct PWM writes. 
  * This "brute force" method sets a flat curve where all temperature
  * points result in the same fan speed.
- *
+ * 
  * Based on LibreHardwareMonitor implementation:
  * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/commit/a55a7a772e5fee7a91f277b01032dc1e8a225e7c
  */
@@ -912,23 +911,20 @@ static bool start_fan_cfg_update(struct nct6687_data *data, int fan)
 	u8 engsts;
 
 	engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
-	if (!(engsts & NCT6687_FAN_CFG_LOCK) && (engsts & NCT6687_FAN_CFG_PHASE))
-	{
+	if (!(engsts & NCT6687_FAN_CFG_LOCK) && (engsts & NCT6687_FAN_CFG_PHASE)) {
 		pr_warn("Fan registers are already accessible\n");
 		return true;
 	}
 
 	/* Wait up to a second until config phase is done and config request is clear. */
-	for (i = 0; i < 1000; i++)
-	{
+	for (i = 0; i < 1000; i++) {
 		if (!(nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS) & NCT6687_FAN_CFG_PHASE) &&
-			!(nct6687_read(data, NCT6687_REG_FAN_PWM_COMMAND(fan)) & NCT6687_FAN_CFG_REQ))
+		    !(nct6687_read(data, NCT6687_REG_FAN_PWM_COMMAND(fan)) & NCT6687_FAN_CFG_REQ))
 			break;
 		msleep(1);
 	}
 
-	if (i == 1000)
-	{
+	if (i == 1000) {
 		pr_err("EC is stuck in configuration phase for too long\n");
 		return false;
 	}
@@ -936,16 +932,14 @@ static bool start_fan_cfg_update(struct nct6687_data *data, int fan)
 	nct6687_write(data, NCT6687_REG_FAN_PWM_COMMAND(fan), NCT6687_FAN_CFG_REQ);
 
 	/* Wait up to a second until EC enters config phase and unlocks the register set. */
-	for (i = 0; i < 1000; i++)
-	{
-		engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
+	for (i = 0; i < 1000; i++) {
+	    engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
 		if (!(engsts & NCT6687_FAN_CFG_LOCK) && (engsts & NCT6687_FAN_CFG_PHASE))
 			break;
 		msleep(1);
 	}
 
-	if (i == 1000)
-	{
+	if (i == 1000) {
 		pr_err("Failed to gain access to fan configuration registers\n");
 		return false;
 	}
@@ -960,8 +954,7 @@ static void finish_fan_cfg_update(struct nct6687_data *data, int fan)
 	u8 donecmd;
 
 	engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
-	if ((engsts & NCT6687_FAN_CFG_LOCK) || !(engsts & NCT6687_FAN_CFG_PHASE))
-	{
+	if ((engsts & NCT6687_FAN_CFG_LOCK) || !(engsts & NCT6687_FAN_CFG_PHASE)) {
 		pr_warn("Fan registers are already not accessible\n");
 		return;
 	}
@@ -977,8 +970,7 @@ static void finish_fan_cfg_update(struct nct6687_data *data, int fan)
 	nct6687_write(data, NCT6687_REG_FAN_PWM_COMMAND(fan), donecmd);
 
 	/* Wait up to a second until EC checks new configuration. */
-	for (i = 0; i < 1000; i++)
-	{
+	for (i = 0; i < 1000; i++) {
 		engsts = nct6687_read(data, NCT6687_REG_FAN_ENGINE_STS);
 		if (engsts & NCT6687_FAN_CFG_CHECK_DONE)
 			break;
@@ -1017,14 +1009,10 @@ static ssize_t store_pwm(struct device *dev, struct device_attribute *attr, cons
 	mode = (u8)(mode | bitMask);
 	nct6687_write(data, NCT6687_REG_FAN_CTRL_MODE(index), mode);
 
-	if (start_fan_cfg_update(data, index))
-	{
-		if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_btf)
-		{
+	if (start_fan_cfg_update(data, index)) {
+		if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_fan_brute_force) {
 			nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), val);
-		}
-		else
-		{
+		} else {
 			nct6687_write(data, NCT6687_REG_PWM_WRITE(index), val);
 		}
 		finish_fan_cfg_update(data, index);
@@ -1111,14 +1099,10 @@ static void nct6687_restore_fan_control(struct nct6687_data *data, int index)
 
 		nct6687_write(data, NCT6687_REG_FAN_CTRL_MODE(index), mode);
 
-		if (start_fan_cfg_update(data, index))
-		{
-			if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_btf)
-			{
+		if (start_fan_cfg_update(data, index)) {
+			if (index > 1 && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_fan_brute_force) {
 				nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), data->_initialFanPwmCommand[index]);
-			}
-			else
-			{
+			} else {
 				nct6687_write(data, NCT6687_REG_PWM_WRITE(index), data->_initialFanPwmCommand[index]);
 			}
 			finish_fan_cfg_update(data, index);
@@ -1244,11 +1228,11 @@ static void nct6687_setup_pwm(struct nct6687_data *data)
 		data->pwm_enable[i] = nct6687_get_pwm_enable(data, i);
 
 		pr_debug("nct6687_setup_pwm[%d], addr=%04X, pwm=%d, pwm_enable=%d, _initialFanPwmCommand=%d\n",
-				 i,
-				 NCT6687_REG_FAN_PWM_COMMAND(i),
-				 data->pwm[i],
-				 data->pwm_enable[i],
-				 data->_initialFanPwmCommand[i]);
+		         i,
+		         NCT6687_REG_FAN_PWM_COMMAND(i),
+		         data->pwm[i],
+		         data->pwm_enable[i],
+		         data->_initialFanPwmCommand[i]);
 	}
 }
 
@@ -1409,28 +1393,26 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 
 	pr_debug("found chip ID: 0x%04x\n", val);
 
-	switch (val & SIO_ID_MASK)
-	{
-	case SIO_NCT6683_ID:
-		sio_data->kind = nct6683;
-		break;
-	case SIO_NCT6686_ID:
-		sio_data->kind = nct6686;
-		break;
-	case SIO_NCT6687D_ID:
-	case SIO_NCT6687_ID:
-		sio_data->kind = nct6687;
-		break;
-	default:
-		if (force)
-		{
-			sio_data->kind = nct6687;
-			break;
+       switch (val & SIO_ID_MASK) {
+        case SIO_NCT6683_ID:
+                sio_data->kind = nct6683;
+                break;
+        case SIO_NCT6686_ID:
+                sio_data->kind = nct6686;
+                break;
+        case SIO_NCT6687D_ID:
+        case SIO_NCT6687_ID:
+                sio_data->kind = nct6687;
+                break;
+        default:
+		if (force){
+                 sio_data->kind = nct6687;
+                 break;
 		}
-		if (val != 0xffff)
-			pr_debug("unsupported chip ID: 0x%04x\n", val);
-		goto fail;
-	}
+                if (val != 0xffff)
+                        pr_debug("unsupported chip ID: 0x%04x\n", val);
+                goto fail;
+        }
 
 	/* We have a known chip, find the HWM I/O address */
 	superio_select(sioaddr, NCT6687_LD_HWM);

--- a/nct6687.c
+++ b/nct6687.c
@@ -384,59 +384,53 @@ enum nct6687_fan_config_type
 
 /*
  * MSI boards that require fan_config=msi_alt1 for proper system fan control
- * These boards use different PWM control registers and require 7-point fan curve writes
+ * These boards use different PWM control registers and require 7-point fan curve writes to adjust system fan speeds
  *
- * Board names with MS-7Exx codes are unique enough - no vendor match needed.
- *
- * Based on LibreHardwareMonitor implementation:
- * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/commit/a55a7a772e5fee7a91f277b01032dc1e8a225e7c
+ * Based on LibreHardwareMonitor NCT6687DR chip detection:
+ * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
  */
 static const struct dmi_system_id nct6687_msi_alt_boards[] __initconst = {
-	{
-		.matches = {
-			DMI_MATCH(DMI_BOARD_NAME, "MAG Z890 TOMAHAWK WIFI (MS-7E32)"),
-		},
-	},
-	{
-		.matches = {
-			DMI_MATCH(DMI_BOARD_NAME, "MAG X870E TOMAHAWK WIFI (MS-7E26)"),
-		},
-	},
-	{
-		.matches = {
-			DMI_MATCH(DMI_BOARD_NAME, "MPG X870E CARBON WIFI (MS-7E27)"),
-		},
-	},
-	{
-		.matches = {
-			DMI_MATCH(DMI_BOARD_NAME, "MAG B850M MORTAR WIFI (MS-7E28)"),
-		},
-	},
-	{
-		.matches = {
-			DMI_MATCH(DMI_BOARD_NAME, "MEG Z890 ACE (MS-7E29)"),
-		},
-	},
-	{
-		.matches = {
-			DMI_MATCH(DMI_BOARD_NAME, "MPG Z890 CARBON WIFI (MS-7E30)"),
-		},
-	},
-	{
-		.matches = {
-			DMI_MATCH(DMI_BOARD_NAME, "PRO Z890-A WIFI (MS-7E34)"),
-		},
-	},
-	{
-		.matches = {
-			DMI_MATCH(DMI_BOARD_NAME, "MPG B850 EDGE TI WIFI (MS-7E35)"),
-		},
-	},
-	{
-		.matches = {
-			DMI_MATCH(DMI_BOARD_NAME, "PRO X870-P WIFI (MS-7E36)"),
-		},
-	},
+	// B840 Series
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B840-P WIFI (MS-7E57)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B840M GAMING PLUS WIFI6E (MS-7E77)")}},
+
+	// B850 Series
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B850 GAMING PLUS WIFI (MS-7E56)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B850 GAMING PLUS WIFI6E (MS-7E80)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B850M GAMING PLUS WIFI6E (MS-7E81)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B850-P WIFI (MS-7E56)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B850M-A WIFI (MS-7E66)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B850M-P WIFI (MS-7E71)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MAG B850M MORTAR WIFI (MS-7E61)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MAG B850 TOMAHAWK MAX WIFI (MS-7E62)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MPG B850 EDGE TI WIFI (MS-7E62)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MPG B850I EDGE TI WIFI (MS-7E79)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B850MPOWER (MS-7E83)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B850-S WIFI6E (MS-7E80)")}},
+
+	// X870 Series
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "X870 GAMING PLUS WIFI (MS-7E47)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "X870E GAMING PLUS WIFI (MS-7E70)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MAG X870 TOMAHAWK WIFI (MS-7E51)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO X870-P WIFI (MS-7E47)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO X870E-P WIFI (MS-7E70)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MAG X870E TOMAHAWK WIFI (MS-7E59)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MPG X870E CARBON WIFI (MS-7E49)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MPG X870E EDGE TI WIFI (MS-7E59)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MEG X870E GODLIKE (MS-7E48)")}},
+
+	// Z890 Series
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MEG Z890 ACE (MS-7E22)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MEG Z890M ACE (MS-7E23)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MPG Z890 CARBON WIFI (MS-7E17)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MPG Z890M CARBON WIFI (MS-7E18)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MPG Z890 EDGE TI WIFI (MS-7E19)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MPG Z890I EDGE TI WIFI (MS-7E33)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "Z890 GAMING PLUS WIFI (MS-7E34)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MAG Z890 TOMAHAWK WIFI (MS-7E32)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO Z890-A WIFI (MS-7E32)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO Z890-P WIFI (MS-7E34)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO Z890-S WIFI (MS-7E54)")}},
 	{}};
 
 static int nct6687_fan_config_type = FAN_CONFIG_DEFAULT; // default

--- a/nct6687.c
+++ b/nct6687.c
@@ -1201,6 +1201,7 @@ static void nct6687_restore_fan_control(struct nct6687_data *data, int index)
 
 		if (start_fan_cfg_update(data, index))
 		{
+			// Use same write method as store_pwm: brute force for MSI alt boards, normal write otherwise
 			if (index >= NCT6687_FIRST_SYSTEM_FAN_INDEX && nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 && msi_fan_brute_force)
 			{
 				nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), data->_initialFanPwmCommand[index]);


### PR DESCRIPTION
Hallo @Fred78290, :wave: 
 
LGTM. :+1:
I've done some testing. In the end, a lingering doubt will remain because we don't have definitive data.
Our results and trust in LHM's functionality are probably the only options.
For this reason, I've disabled the `msi_fan_brute_force` setting by default. The user has to activate the option themselves. 
It works very well on my Z890 board, and also on @murdurn B850 board, as he confirmed to me. 
That seems like a good point to me, since LHM's brute-force method is generally successfully supported on so many different boards.
I haven't seen any error messages about it in the LHM forum.


**So let's merge it.** :rocket: 

> [!NOTE] 
>  This PR introduces automatic MSI board detection and adds support for advanced fan curve control on MSI motherboards with NCT6687DR chips.

**Main Features:**

Automatic MSI Board Detection:

> - Adds DMI-based detection for 36 MSI motherboards (B840, B850, X870, X870E, Z890 series)
> - Automatically enables `msi_alt1` fan configuration when supported boards are detected
> - Includes ATX and Micro-ATX variants (MEG Z890 ACE, MEG Z890M ACE, MPG Z890 CARBON WIFI, etc.)   from: https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs#L409
> - Detection message logged in dmesg for verification


MSI Fan Brute Force Mode (msi_fan_brute_force):

> - New optional module parameter ` msi_fan_brute_force` (default: false) [ALPHA]
> - Implements 7-point fan curve control for system fans (indices 2-7)
> - Based on LibreHardwareMonitor NCT6687DR implementation
> - Only affects system fans controlled by BIOS (not CPU fan or pump fan)
> - Includes PWM optimization: skips curve rewrites when target value already matches
> - Detection message logged in dmesg for verification
> - Usage: `modprobe nct6687 msi_fan_brute_force=1`


Code Structure Improvements:

> - Added `NCT6687_FAN_CURVE_POINTS` (7) and `NCT6687_FAN_CURVE_POINT_SIZE` (2) constants
> - Introduced `nct6687_write_all_curve()` function for 7-point curve writes
> - Improved code readability with symbolic constants instead of magic numbers (LHM does it that way? Looks messy)
> - Small, small code formatting. Sorry :kissing_closed_eyes: 


Technical Details:

> - Fan curve control writes PWM values to register pairs (2 registers per curve point)
> - System fans (SYS1-6) use alternative registers: 0xBF8-0xC70 (curve), 0xE00-0xE05 (PWM), 0x154-0x15E (RPM reversed)
> - CPU/Pump fans continue using standard registers (0xA28/0xA29)
> - Implementation matches LibreHardwareMonitor's `Set6687DRControl()` method:
> https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs#L1161

   
Board Coverage:

> - B840 Series: 2 boards
> - B850 Series: 13 boards
> - X870 Series: 9 boards
> - Z890 Series: 12 boards (including Micro-ATX variants)
> Total: 36 boards automatically detected


Documentation:

> - Updated README.md with module parameter documentation
> - Added troubleshooting section for MSI board detection

Tested on :  
> - MSI MAG Z890 TOMAHAWK WIFI
> - B850 board from @murdurn
> with successful automatic detection and
Fan curve control functional with `msi_fan_brute_force=1`