### PR TITLE
feat: Add Clang/LLVM support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,8 @@ commithash  := $(shell git rev-parse --short HEAD 2>/dev/null)
 fedoraver   := $(shell sed -n 's/.*Fedora release \([^ ]*\).*/\1/p' /etc/fedora-release 2>/dev/null || echo 0)
 
 # Detect if the kernel was built with clang/LLVM and use the same compiler
-KERNEL_CC := $(shell cat /lib/modules/${kver}/build/.config 2>/dev/null | grep -q CONFIG_CC_IS_CLANG=y && echo clang)
+KERNEL_CC := $(shell grep -qs CONFIG_CC_IS_CLANG=y /lib/modules/${kver}/build/.config && echo clang)
 ifeq ($(KERNEL_CC),clang)
-  CC := clang
   LLVM_FLAGS := LLVM=1
 endif
 
@@ -17,14 +16,13 @@ build:
 	rm -rf ${curpwd}/${kver}
 	mkdir -p ${curpwd}/${kver}
 	cp ${curpwd}/Makefile ${curpwd}/nct6687.c ${curpwd}/${kver}
-	cd ${curpwd}/${kver}
 	make -C /lib/modules/${kver}/build M=${curpwd}/${kver} $(LLVM_FLAGS) modules
 install: build
 	sudo cp ${curpwd}/${kver}/nct6687.ko /lib/modules/${kver}/kernel/drivers/hwmon/
 	sudo depmod
 	sudo modprobe nct6687
 clean:
-	[ -d "${curpwd}/${kver}" ] && make -C /lib/modules/${kver}/build M=${curpwd}/${kver} $(LLVM_FLAGS) clean
+	[ -d "${curpwd}/${kver}" ] && make -C /lib/modules/${kver}/build M=${curpwd}/${kver} $(LLVM_FLAGS) clean || true
 
 
 akmod/build:
@@ -55,7 +53,7 @@ akmod: akmod/install
 
 
 dkms/build:
-	make -C /lib/modules/${kver}/build M=${curpwd} modules
+	make -C /lib/modules/${kver}/build M=${curpwd} $(LLVM_FLAGS) modules
 
 dkms/install:
 	rm -rf ${curpwd}/dkms
@@ -68,7 +66,7 @@ dkms/install:
 
 dkms/clean:
 	sudo dkms remove nct6687d/1 --all
-	make -C /lib/modules/${kver}/build M=${curpwd} clean
+	make -C /lib/modules/${kver}/build M=${curpwd} $(LLVM_FLAGS) clean
 
 debian/changelog: FORCE
 	git --no-pager log \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ build:
 	cd ${curpwd}/${kver}
 	make -C /lib/modules/${kver}/build M=${curpwd}/${kver} $(LLVM_FLAGS) modules
 install: build
-	sudo dkms remove nct6687d/1 --all
 	sudo cp ${curpwd}/${kver}/nct6687.ko /lib/modules/${kver}/kernel/drivers/hwmon/
 	sudo depmod
 	sudo modprobe nct6687

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 	cd ${curpwd}/${kver}
 	make -C /lib/modules/${kver}/build M=${curpwd}/${kver} $(LLVM_FLAGS) modules
 install: build
-	sudo dkms remove nct6687d/1 --all; \
+	sudo dkms remove nct6687d/1 --all
 	sudo cp ${curpwd}/${kver}/nct6687.ko /lib/modules/${kver}/kernel/drivers/hwmon/
 	sudo depmod
 	sudo modprobe nct6687

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ install: build
 	sudo cp ${curpwd}/${kver}/nct6687.ko /lib/modules/${kver}/kernel/drivers/hwmon/
 	sudo depmod
 	sudo modprobe nct6687
-
 clean:
 	[ -d "${curpwd}/${kver}" ] && make -C /lib/modules/${kver}/build M=${curpwd}/${kver} $(LLVM_FLAGS) clean
 

--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,27 @@ commitcount := $(shell git rev-list --all --count 2>/dev/null)
 commithash  := $(shell git rev-parse --short HEAD 2>/dev/null)
 fedoraver   := $(shell sed -n 's/.*Fedora release \([^ ]*\).*/\1/p' /etc/fedora-release 2>/dev/null || echo 0)
 
+# Detect if the kernel was built with clang/LLVM and use the same compiler
+KERNEL_CC := $(shell cat /lib/modules/${kver}/build/.config 2>/dev/null | grep -q CONFIG_CC_IS_CLANG=y && echo clang)
+ifeq ($(KERNEL_CC),clang)
+  CC := clang
+  LLVM_FLAGS := LLVM=1
+endif
 
 build:
 	rm -rf ${curpwd}/${kver}
 	mkdir -p ${curpwd}/${kver}
 	cp ${curpwd}/Makefile ${curpwd}/nct6687.c ${curpwd}/${kver}
 	cd ${curpwd}/${kver}
-	make -C /lib/modules/${kver}/build M=${curpwd}/${kver} modules
+	make -C /lib/modules/${kver}/build M=${curpwd}/${kver} $(LLVM_FLAGS) modules
 install: build
+	sudo dkms remove nct6687d/1 --all; \
 	sudo cp ${curpwd}/${kver}/nct6687.ko /lib/modules/${kver}/kernel/drivers/hwmon/
 	sudo depmod
 	sudo modprobe nct6687
+
 clean:
-	[ -d "${curpwd}/${kver}" ] && make -C /lib/modules/${kver}/build M=${curpwd}/${kver} clean
+	[ -d "${curpwd}/${kver}" ] && make -C /lib/modules/${kver}/build M=${curpwd}/${kver} $(LLVM_FLAGS) clean
 
 
 akmod/build:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Just add nct6687 into /etc/modules
 
 ### Arch-Linux with systemd
 
+[See entry in the Arch Wiki](https://wiki.archlinux.org/title/Lm_sensors#MSI_MAG_B650_/_Z890_TOMAHAWK_WIFI_(MS-7D75/MS-7E32)_/_MAG_B550_MORTAR_WIFI_(MS-7C94))
+
+
 `sudo sh -c 'echo "nct6687" >> /etc/modules-load.d/nct6687.conf'`
 
 <br>

--- a/nct6687.c
+++ b/nct6687.c
@@ -389,7 +389,7 @@ enum nct6687_fan_config_type
  * Based on LibreHardwareMonitor NCT6687DR chip detection:
  * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
  */
-static const struct dmi_system_id nct6687_msi_alt_boards[] __initconst = {
+static const struct dmi_system_id nct6687_msi_alt_boards[] = {
 	// B840 Series
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B840-P WIFI (MS-7E57)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B840M GAMING PLUS WIFI6E (MS-7E77)")}},


### PR DESCRIPTION
Hey @Fred78290

I compiled my kernel with Clang and had to adjust the Makefile for it to build the module successfully. Others might encounter the same issue when using Clang/LLVM. I believe CachyOS also builds its kernels with Clang. Otherwise, everything should work as expected.

Changes:

- Auto-detect if kernel was built with Clang and pass LLVM=1 accordingly
- Remove `__initconst` from `nct6687_msi_alt_boards[]` to fix section mismatch warning message
- Remove no-op cd in build target
- Add up-to-date Arch Wiki link

KISS <3