### PR TITLE
Remove 0xd450 id, it's not an nct6687

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -1509,7 +1509,6 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 	case SIO_NCT6686_ID:
 		sio_data->kind = nct6686;
 		break;
-	case SIO_NCT6687D_ID:
 	case SIO_NCT6687_ID:
 		sio_data->kind = nct6687;
 		break;

--- a/nct6687.c
+++ b/nct6687.c
@@ -124,7 +124,6 @@ static const char *const nct6687_chip_names[] = {
 #define SIO_NCT6681_ID 0xb270 /* for later */
 #define SIO_NCT6683_ID 0xc730
 #define SIO_NCT6686_ID 0xd440
-#define SIO_NCT6687D_ID 0xd450 /* NCT6687 ???*/
 #define SIO_NCT6687_ID 0xd590
 #define SIO_ID_MASK 0xFFF0
 


### PR DESCRIPTION
Removes 0xd450 as a valid id for this driver. It's covered by the nct6775 driver and is an nct6797D. From PR #21. It seems the user erroneously added it when they meant to add just `0xd592`. If there are future problems we can resolve them with a new issue. But this conflict has led to system issues for a user we helped over on the CC discord. Solves #163 