### PR TITLE
docs: prevent fan_config=msi_alt1 misconfiguration on non-DR MSI boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,25 @@ On MSI motherboards, `msi_alt1` configuration is automatically detected and enab
 You can verify this in `dmesg` after loading the module:
 ```
 nct6687 nct6687.2592: Detected MSI board; using alternative fan configuration (msi_alt1)
+nct6687 nct6687.2592: active fan config=msi_alt1, SYS_FAN reg_rpm=0x015E/0x015C/0x015A
 ```
 
+The second line is always printed and shows the EC offsets the driver reads
+for SYS_FAN #1/#2/#3. Use it to confirm the right mapping is active.
+
 If you have a non-MSI motherboard with this issue, try using module parameter `fan_config=msi_alt1` manually.
+
+> **Warning — do NOT force `fan_config=msi_alt1` on non-listed MSI boards.**
+> Only the NCT6687DR-equipped MSI families (B840/B850/X870/X870E/Z890) are
+> compatible with `msi_alt1`. Earlier MSI series with the plain NCT6687D chip
+> — including **B650/B660/X670/Z690/Z790** — use the *default* register
+> mapping and are auto-detected correctly without any module parameter.
+>
+> If you previously set `options nct6687 fan_config=msi_alt1` in
+> `/etc/modprobe.d/` on one of those boards as a troubleshooting attempt,
+> remove it: forcing `msi_alt1` makes the driver read EC offsets
+> `0x154-0x15E` which are zero on non-DR variants, causing all SYS_FAN to
+> report `0 RPM` while CPU_FAN keeps working. The `active fan config=...`
+> dmesg line above will reveal a stale forced setting at a glance.
+>
+> Reference: issue #167 (MSI MPG B650 CARBON WIFI, MS-7D74).

--- a/nct6687.c
+++ b/nct6687.c
@@ -388,6 +388,14 @@ enum nct6687_fan_config_type
  *
  * Based on LibreHardwareMonitor NCT6687DR chip detection:
  * https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+ *
+ * NOTE: only NCT6687DR-equipped MSI boards (B840/B850/X870/X870E/Z890) belong
+ * here. Earlier MSI series with the plain NCT6687D chip (B650/B660/X670/Z690/
+ * Z790, etc.) use the *default* register mapping at 0x140-0x14E and must NOT
+ * be added to this list. Forcing fan_config=msi_alt1 on those boards reads
+ * EC offsets 0x154-0x15E which are unused (zero) on non-DR variants, causing
+ * all SYS_FAN inputs to report 0 RPM. See issue #167 for a worked example
+ * on MSI MPG B650 CARBON WIFI (MS-7D74).
  */
 static const struct dmi_system_id nct6687_msi_alt_boards[] = {
 	// B840 Series
@@ -1385,6 +1393,17 @@ static int nct6687_probe(struct platform_device *pdev)
 		dev_info(dev, "MSI fan brute force mode: %s\n",
 				 msi_fan_brute_force ? "enabled" : "disabled");
 	}
+
+	/*
+	 * Always announce the active fan config so module parameter mismatches
+	 * (e.g. a stale fan_config=msi_alt1 in /etc/modprobe.d/ on a board
+	 * that needs the default mapping) are obvious from dmesg.
+	 */
+	dev_info(dev, "active fan config=%s, SYS_FAN reg_rpm=0x%04X/0x%04X/0x%04X\n",
+		 nct6687_fan_config_type == FAN_CONFIG_MSI_ALT1 ? "msi_alt1" : "default",
+		 nct6687_fan_config_active[2].reg_rpm,
+		 nct6687_fan_config_active[3].reg_rpm,
+		 nct6687_fan_config_active[4].reg_rpm);
 
 	pr_debug("nct6687_probe addr=0x%04X, sioreg=0x%04X\n", data->addr, data->sioreg);
 


### PR DESCRIPTION
## Summary

Closes #167 (issue I opened earlier this week reporting SYS_FAN at 0 RPM on MSI MPG B650 CARBON WIFI / MS-7D74).

**Root cause turned out to be a user-level misconfiguration, not a missing board profile**: I had `options nct6687 fan_config=msi_alt1` in `/etc/modprobe.d/nct6687.conf` from earlier troubleshooting. Removing that line and letting the driver use the default mapping makes all three SYS_FAN report correctly:

```
Before (forced msi_alt1):
  System Fan #1:    0 RPM
  System Fan #2:    0 RPM
  System Fan #3:    0 RPM

After (default mapping, auto-selected):
  System Fan #1:  627 RPM   (NF-A14)
  System Fan #2: 1680 RPM   (NZXT F120Q)
  System Fan #3:  826 RPM   (NZXT F120Q)
```

Diagnosis was confirmed by adding a one-shot EC register dump in `probe()`: EC offsets `0x144`/`0x146`/`0x148` (default profile) held the correct RPM values all along, while `0x154-0x15E` (msi_alt1) were uniformly zero on the MS-7D74. The B650 series uses the plain NCT6687D chip — not NCT6687DR — and `LpcIO.cs` in LibreHardwareMonitor confirms only B840/B850/X870/Z890 are mapped to the DR variant.

So instead of adding a board profile, this PR adds the diagnostics and documentation that would have let me spot the misconfig immediately.

## Changes

1. **`nct6687.c` — unconditional dmesg line in `probe()`** showing the active fan config name and the EC offsets the driver will read for SYS_FAN #1/#2/#3:

   ```
   nct6687 nct6687.2592: active fan config=default, SYS_FAN reg_rpm=0x0144/0x0146/0x0148
   ```

   A stale forced `msi_alt1` now reveals itself as `reg_rpm=0x015E/0x015C/0x015A` and the user can correlate that with the (zero) values they see.

2. **`nct6687.c` — extended comment over `nct6687_msi_alt_boards[]`** spelling out that only NCT6687DR-equipped MSI series belong there and that earlier series (B650/B660/X670/Z690/Z790) must not be added — with a brief note on what goes wrong if they are.

3. **`README.md` — "Only CPU & Pump show RPM values" section** gets the new dmesg example and an explicit warning block telling users with older MSI boards not to force `fan_config=msi_alt1` and how to clean up if they did.

No functional/behavioural change to the driver path: this is purely a +1 diagnostic line at probe time plus documentation.

## Test plan

- [x] Builds cleanly on Linux 6.12.87 (Gentoo)
- [x] `modprobe nct6687` shows the new line and all three SYS_FAN read correctly on MS-7D74 with the default profile
- [x] `modprobe nct6687 fan_config=msi_alt1` still works on supported boards (regression-safe — only adds a log line)
- [ ] Maintainer to confirm the new warning paragraph in README reads well in their style