### PR TITLE
fix: report standard hwmon ABI value 2 for pwm_enable auto mode

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -75,12 +75,35 @@ enum kinds
 	nct6687
 };
 
+/*
+ * pwm*_enable values follow the Linux hwmon ABI
+ * (Documentation/hwmon/sysfs-interface):
+ *
+ *   1 - manual fan speed control (write pwm*)
+ *   2 - automatic / "thermal cruise" — hand control back to the EC's
+ *       firmware fan curve. NCT668x exposes several automatic profiles
+ *       internally; this driver does not currently let userspace pick
+ *       between them, so 2 simply means "clear the manual-control bit".
+ *
+ * The driver historically reported 99 for the auto state and rejected
+ * any write other than 1 or 99. That deviated from the ABI and made
+ * standard userspace (lm-sensors `fancontrol`, ventd, etc.) trip on
+ * `-EINVAL` when restoring auto mode on shutdown. Both values are now
+ * accepted in store_pwm_enable; show_pwm_enable always returns the
+ * ABI-conforming 1 or 2.
+ */
 enum pwm_enable
 {
 	manual_mode = 1,
-	// There are multiple automatic modes, none of which is configurable by this module yet.
-	firmware_mode = 99,
+	auto_mode = 2,
 };
+
+/*
+ * Legacy auto-mode value historically reported / accepted by this
+ * driver. Still accepted in store_pwm_enable for callers that scripted
+ * around the old behaviour; never reported in show_pwm_enable.
+ */
+#define NCT6687_LEGACY_AUTO_MODE 99
 
 static bool force;
 static bool manual;
@@ -794,7 +817,7 @@ static enum pwm_enable nct6687_get_pwm_enable(struct nct6687_data *data, int ind
 	{
 		return manual_mode;
 	}
-	return firmware_mode;
+	return auto_mode;
 }
 
 static void nct6687_update_fans(struct nct6687_data *data)
@@ -1146,7 +1169,7 @@ static ssize_t store_pwm_enable(struct device *dev, struct device_attribute *att
 
 	if (index >= NCT6687_NUM_REG_FAN || kstrtoul(buf, 10, &val))
 		return -EINVAL;
-	if (val != manual_mode && val != firmware_mode)
+	if (val != manual_mode && val != auto_mode && val != NCT6687_LEGACY_AUTO_MODE)
 		return -EINVAL;
 
 	mutex_lock(&data->update_lock);
@@ -1160,12 +1183,21 @@ static ssize_t store_pwm_enable(struct device *dev, struct device_attribute *att
 	{
 		mode = (u8)(mode | bitMask);
 	}
-	else if (val == firmware_mode)
+	else
 	{
+		/* auto_mode or NCT6687_LEGACY_AUTO_MODE — clear the manual-control bit. */
 		mode = (u8)(mode & ~bitMask);
 	}
 
 	nct6687_write(data, NCT6687_REG_FAN_CTRL_MODE(index), mode);
+
+	/*
+	 * Keep the cached pwm_enable consistent with the register we just wrote
+	 * so the immediate read-back returns the value the user just stored,
+	 * not the previous value cached on the last nct6687_update_device tick.
+	 * Legacy value 99 is normalised to the ABI-conforming auto_mode (2).
+	 */
+	data->pwm_enable[index] = (val == manual_mode) ? manual_mode : auto_mode;
 
 	mutex_unlock(&data->update_lock);
 


### PR DESCRIPTION
## Problem

`pwm*_enable` historically reports `99` for the firmware/auto state and rejects any write other than `1` or `99`. The Linux hwmon ABI ([Documentation/hwmon/sysfs-interface](https://www.kernel.org/doc/html/latest/hwmon/sysfs-interface.html)) defines:

```
1 - manual fan speed control (write pwm*)
2 - automatic / "thermal cruise"
```

Standard userspace fan controllers (lm-sensors `fancontrol`, ventd, fan2go, …) write `2` on shutdown / panic to hand the fan back to the EC's auto curve, and read `2` in their state machines. Reporting `99` and rejecting `2` breaks that integration:

- Tools log `-EINVAL` when restoring auto mode and either leave the fan in the last manual PWM (safety regression for panic / daemon-exit paths) or fall into retry loops.
- Out-of-tree daemon `ventd`'s restore-on-stop watchdog logs the underlying write error as:
  ```
  watchdog: failed to restore pwm_enable
    err="hwmon: write pwm_enable .../pwm1_enable=2: invalid argument"
  ```

## Fix

- `show_pwm_enable` returns `2` (not `99`) for the auto state.
- `store_pwm_enable` accepts `2` as the ABI synonym for the legacy `99`.
- `store_pwm_enable` keeps accepting `99` (normalised to `2` in the cached value) for any caller still scripted around the old behaviour.
- After a successful store, the cached `data->pwm_enable[index]` is updated so an immediate read-back returns what the user just wrote, not the value cached on the last `update_device` tick. (`store_pwm` already does the equivalent update for PWM duty cycle.)

## Test plan

Tested on **MSI PRO Z690-A DDR4 (MS-7D25)** on kernels **7.0.8-200.fc44.x86_64** and **7.0.2-3-pve**:

| Write | Before | After |
|---|---|---|
| `echo 1 > pwm1_enable` | ok, read=1 | ok, read=1 |
| `echo 2 > pwm1_enable` | `write error: Invalid argument` | ok, read=2 |
| `echo 99 > pwm1_enable` | ok, read=99 | ok, read=2 (normalised) |
| `echo 5 > pwm1_enable` | `Invalid argument` | `Invalid argument` |

Auto-mode fans on probe report `pwm*_enable=2` after the patch (`99` before).

## Notes

- Pure userspace ABI fix; the EC bit semantics are unchanged (set = manual, clear = auto).
- The cache-update line in `store_pwm_enable` fixes a pre-existing read-after-write staleness that becomes more visible with the new value-2 acceptance — kept in the same commit because it's tightly coupled to the same code path. Happy to split if you prefer.