### PR TITLE
fix: hold EC_io_lock across the data read in nct6687_read

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -691,12 +691,22 @@ static u16 nct6687_read(struct nct6687_data *data, u16 address)
 	u8 page = (u8)(address >> 8);
 	u8 index = (u8)(address & 0xFF);
 	int res;
+
+	/*
+	 * EC access is a page-select + index-set + data-read sequence on a
+	 * shared 4-byte I/O window. The data read MUST be inside the lock
+	 * with the matching page/index writes — otherwise a concurrent
+	 * nct6687_read() or nct6687_write() from another thread can
+	 * reprogram page/index between our writes and our inb_p, and we
+	 * return data for the wrong register. nct6687_write() already
+	 * holds the lock across its data write; do the same here.
+	 */
 	mutex_lock(&data->EC_io_lock);
 	outb_p(EC_SPACE_PAGE_SELECT, data->addr + EC_SPACE_PAGE_REGISTER_OFFSET);
 	outb_p(page, data->addr + EC_SPACE_PAGE_REGISTER_OFFSET);
 	outb_p(index, data->addr + EC_SPACE_INDEX_REGISTER_OFFSET);
-	mutex_unlock(&data->EC_io_lock);
 	res = inb_p(data->addr + EC_SPACE_DATA_REGISTER_OFFSET);
+	mutex_unlock(&data->EC_io_lock);
 
 	return res;
 }


### PR DESCRIPTION
## Problem

`nct6687_read` releases `EC_io_lock` between the page-select / index writes and the `inb_p` data read:

```c
mutex_lock(&data->EC_io_lock);
outb_p(EC_SPACE_PAGE_SELECT, ...);
outb_p(page, ...);
outb_p(index, ...);
mutex_unlock(&data->EC_io_lock);     // <-- released here
res = inb_p(data->addr + EC_SPACE_DATA_REGISTER_OFFSET);
```

EC access is a page-select + index-set + data-read sequence on a shared 4-byte I/O window. Between the unlock and the `inb_p`, another thread can call `nct6687_read` or `nct6687_write` and reprogram page/index — and our subsequent `inb_p` returns data for the wrong register.

`nct6687_write` (the symmetric writer) already holds the lock across all four I/O ops, which is what makes the race visible: a reader's `inb_p` can fall in between a concurrent writer's index-set and data-write, picking up the writer's index.

## Real-world impact

The driver runs at least three concurrent readers in `nct6687_update_device` (fans, temperatures, voltages) plus userspace sysfs readers, and a single writer per `store_pwm` / `store_pwm_enable`. Under contention the torn-page-then-read produces spurious readings — fan RPM values appearing in voltage attributes, etc. The window is narrow (three `outb_p` between unlock and read) but observable on a system with a busy fan-control daemon polling alongside `nct6687_update_device`'s HZ cadence.

## Fix

Move `mutex_unlock` to after the `inb_p`, mirroring `nct6687_write`. The entire page-set + index-set + data-read sequence is now atomic w.r.t. other EC consumers.

## Test plan

- Built on Fedora 44 / 7.0.8-200.fc44.x86_64 and Proxmox VE / 7.0.2-3-pve.
- Live-loaded on MSI PRO Z690-A DDR4 (MS-7D25); all 7 fan tachs + 7 temperatures + 14 voltages read sensible values; PWM writes still take effect (fan RPM changes correctly when writing `pwm1`).
- No performance regression: the additional `inb_p` (~250-500ns) inside the lock is negligible against the four `outb_p` the function already performs.

## Notes

The kernel CI lockdep would have caught the asymmetry between `nct6687_read` and `nct6687_write` but only on a kernel built with `CONFIG_PROVE_LOCKING=y` exercising both functions concurrently. Adding the kernel-doc comment so future readers / static analysers (`smatch`, etc.) can keep this property.