### PR TITLE
fix: use 500 (not 5) for the 0.5°C bit in nct6687_setup_temperatures

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -1313,7 +1313,7 @@ static void nct6687_setup_temperatures(struct nct6687_data *data)
 	{
 		s32 value = (char)nct6687_read(data, NCT6687_REG_TEMP(i));
 		s32 half = (nct6687_read(data, NCT6687_REG_TEMP(i) + 1) >> 7) & 0x1;
-		s32 temperature = (value * 1000) + (5 * half);
+		s32 temperature = (value * 1000) + (500 * half);
 
 		data->temperature[0][i] = temperature;
 		data->temperature[1][i] = temperature;


### PR DESCRIPTION
## Problem

`nct6687_update_temperatures` (runtime) and `nct6687_setup_temperatures` (probe-time seed) compose a millidegree-Celsius temperature from a whole-degree byte plus a 0.5°C bit:

```c
// runtime — correct
s32 temperature = (value * 1000) + (500 * half);

// setup — wrong: 5, not 500
s32 temperature = (value * 1000) + (5 * half);
```

`half` is the 0.5°C bit (bit 7 of `REG_TEMP(i) + 1`). In hwmon's millidegree-Celsius convention that bit is worth `500`, not `5`. The probe-time setup seeds `temperature[1][i]` (running min) and `temperature[2][i]` (running max) with a value off by two decimal places.

## Impact

Self-heals on the first runtime tick when `update_device` overwrites `[0]/[1]/[2]`. But for the ~1s gap between probe and the first updater tick — plus any userspace tool reading `temp*_min`/`temp*_max` immediately on hwmon device appearance — the values are wrong. On a board where the 0.5°C bit happens to be set at boot, `min`/`max` stay 495 m°C off the truth for those sensors until a temperature actually crosses the seeded value.

## Fix

Change `5` to `500` to match the runtime updater.

## Test plan

Built on Fedora 44 / 7.0.8-200.fc44 and Proxmox 7.0.2-3-pve. Module loads, `temp*_input` / `temp*_min` / `temp*_max` read sensible millidegree values immediately after probe.