### PR TITLE
fix: wire suspend/resume through dev_pm_ops, not legacy platform hooks

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -1455,9 +1455,9 @@ static int nct6687_probe(struct platform_device *pdev)
 	return PTR_ERR_OR_ZERO(hwmon_dev);
 }
 
-static int nct6687_suspend(struct platform_device *pdev, pm_message_t state)
+static int nct6687_suspend(struct device *dev)
 {
-	struct nct6687_data *data = nct6687_update_device(&pdev->dev);
+	struct nct6687_data *data = nct6687_update_device(dev);
 
 	mutex_lock(&data->update_lock);
 	data->hwm_cfg = nct6687_read(data, NCT6687_HWM_CFG);
@@ -1466,9 +1466,8 @@ static int nct6687_suspend(struct platform_device *pdev, pm_message_t state)
 	return 0;
 }
 
-static int nct6687_resume(struct platform_device *pdev)
+static int nct6687_resume(struct device *dev)
 {
-	struct device *dev = &pdev->dev;
 	struct nct6687_data *data = dev_get_drvdata(dev);
 
 	mutex_lock(&data->update_lock);
@@ -1482,14 +1481,16 @@ static int nct6687_resume(struct platform_device *pdev)
 	return 0;
 }
 
-// static const struct dev_pm_ops nct6687_dev_pm_ops = {
-// 	.suspend = nct6687_suspend,
-// 	.resume = nct6687_resume,
-// 	.freeze = nct6687_suspend,
-// 	.restore = nct6687_resume,
-// };
+/*
+ * Sleep PM ops via the modern dev_pm_ops path. The legacy
+ * platform_driver.suspend / .resume hooks were not called by the PM
+ * core on any kernel ≥ 5.10 — the only mechanism left is .driver.pm,
+ * so wiring up SIMPLE_DEV_PM_OPS is what actually makes suspend/resume
+ * happen.
+ */
+static SIMPLE_DEV_PM_OPS(nct6687_dev_pm_ops, nct6687_suspend, nct6687_resume);
 
-#define NCT6687_DEV_PM_OPS NULL
+#define NCT6687_DEV_PM_OPS (&nct6687_dev_pm_ops)
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
@@ -1500,8 +1501,6 @@ static struct platform_driver nct6687_driver = {
 	},
 	.probe = nct6687_probe,
 	.remove = nct6687_remove,
-	.suspend = nct6687_suspend,
-	.resume = nct6687_resume,
 };
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
## Problem

The driver's `nct6687_suspend` / `nct6687_resume` callbacks were attached only via the legacy `platform_driver.suspend` / `.resume` slots:

```c
static struct platform_driver nct6687_driver = {
    .driver = {
        .pm = NCT6687_DEV_PM_OPS,   // #define NCT6687_DEV_PM_OPS NULL
    },
    .suspend = nct6687_suspend,      // legacy — ignored by PM core
    .resume  = nct6687_resume,       // legacy — ignored by PM core
};
```

The PM core stopped calling those legacy slots when the platform-bus PM path moved to `dev_pm_ops` (roughly 5.10). On every modern kernel the driver's suspend/resume code never ran:

- `hwm_cfg` byte was never saved before sleep, never restored after sleep
- `data->valid` was never invalidated on resume → cached fan/temp/voltage readings stay stale across S3

A `dev_pm_ops` struct was already present in the source, but commented out, with `NCT6687_DEV_PM_OPS` hard-defined to `NULL`.

This is plausibly the root cause of #111 ("linux 6.12 appears to have broken fan control") — without resume restoring `NCT6687_HWM_CFG`, fan monitoring can stop responding after a sleep cycle until a manual rmmod/modprobe.

## Fix

- Convert `nct6687_suspend` / `nct6687_resume` to `dev_pm_ops` signatures (`struct device *` instead of `struct platform_device *` plus an unused `pm_message_t`).
- Declare the `dev_pm_ops` via `SIMPLE_DEV_PM_OPS`, which maps both `suspend`/`freeze`/`poweroff` to `nct6687_suspend` and `resume`/`thaw`/`restore` to `nct6687_resume` — preserving the hibernate-aware behaviour the commented-out struct intended.
- Point `NCT6687_DEV_PM_OPS` at the new struct.
- Drop the now-dead `.suspend` / `.resume` legacy fields from `platform_driver`.

## Test plan

- Built on Fedora 44 / 7.0.8-200.fc44 and Proxmox 7.0.2-3-pve.
- Module loads cleanly, all hwmon attributes read sensible values.
- `/sys/bus/platform/drivers/nct6687/nct6687.2592` binding intact.
- Full S3 not exercised on the Proxmox test host (suspend disabled). The conversion is a mechanical lift of working logic into the correct registration slot and is the standard pattern used by every in-tree platform_driver hwmon module (`nct6683`, `it87` mainline, `dell_smm_hwmon`, etc.).

## Notes

The pragma silencing `-Wincompatible-pointer-types` is retained because `.remove` still returns `int` (kernel 6.11+ wants `void`). That's a separate concern; happy to address in a follow-up PR.