### PR TITLE
fix: make fan_config a load-time-only module parameter (0660 → 0440)

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -495,7 +495,22 @@ static const struct kernel_param_ops nct6687_fan_config_op_ops = {
 	.set = nct6687_fan_config_op_write_handler,
 	.get = nct6687_fan_config_op_read_handler};
 
-module_param_cb(fan_config, &nct6687_fan_config_op_ops, NULL, 0660);
+/*
+ * fan_config is intentionally a boot-time parameter only (perm 0440 —
+ * world-readable, not writable from sysfs). nct6687_fan_config_active
+ * is a globally-shared pointer that sysfs reader paths dereference
+ * lock-free for every fan/pwm access; allowing runtime writes via
+ * `echo msi_alt1 > /sys/module/nct6687/parameters/fan_config` races
+ * those readers and can produce torn pointer reads on 32-bit hosts
+ * and stale register addresses mid-EC-transaction on 64-bit hosts.
+ *
+ * The .set callback is still wired up because the kernel param core
+ * calls it for `insmod nct6687.ko fan_config=msi_alt1` at module load
+ * time, which is the only point at which switching the active config
+ * is safe (before the platform_device is probed and before any reader
+ * exists).
+ */
+module_param_cb(fan_config, &nct6687_fan_config_op_ops, NULL, 0440);
 
 /* ------------------------------------------------------- */
 struct nct6687_data


### PR DESCRIPTION
## Problem

The \`fan_config\` module parameter is currently registered with perm \`0660\`, allowing root to flip the active fan-config pointer at runtime:

\`\`\`sh
echo msi_alt1 > /sys/module/nct6687/parameters/fan_config
\`\`\`

\`nct6687_fan_config_active\` is a globally-shared pointer that every sysfs reader path dereferences lock-free for fan/pwm/rpm access — e.g. \`NCT6687_REG_FAN_RPM(x)\` expands to \`nct6687_fan_config_active[x].reg_rpm\`. A runtime write races every reader:

- **32-bit hosts**: the pointer itself can be torn.
- **64-bit hosts**: the pointer write is atomic, but mid-EC-transaction the page/index/register triple computed from \`nct6687_fan_config_active[i].reg_rpm\` can fall on one side of the switch and the data read on the other, returning data for a register on the other map.

The runtime-writable path is essentially never the right thing to do anyway: switching the active config does not re-probe, does not re-run \`setup_fans\` / \`setup_pwm\`, and does not reset cached \`_initialFanControlMode\` / \`_initialFanPwmCommand\` state.

## Fix

Drop the perm to \`0440\`: parameter is world-readable for diagnostics but not writable from sysfs. Module-load-time setting via \`insmod nct6687.ko fan_config=msi_alt1\` continues to work because the kernel param core processes load-time values before the perm check.

## Test plan

- Built on Fedora 44 / 7.0.8-200.fc44 and Proxmox 7.0.2-3-pve.
- Module loads cleanly with and without explicit \`fan_config=\`.
- \`cat /sys/module/nct6687/parameters/fan_config\` returns the auto-detected value.
- \`echo X > /sys/module/nct6687/parameters/fan_config\` returns \`-EACCES\` as expected.

## Compatibility note

Users who scripted runtime switching will need to unload + reload the module with the new \`fan_config=\` instead. Given the race described above, that's a strictly safer operation anyway.