### PR TITLE
fix: gate force=1 on Nuvoton NCT668x chip-ID range

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -1534,6 +1534,30 @@ static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 	default:
 		if (force)
 		{
+			/*
+			 * Only allow force=1 on chips whose ID is plausibly in the
+			 * Nuvoton NCT668x family (upper nibble 0xD). Other vendors'
+			 * SuperIOs — ITE IT87xx at 0x87xx, Fintek F71xxx at 0x07xx,
+			 * even Nuvoton's own NCT677x at 0xc8xx-0xc9xx — use
+			 * completely different register maps. Forcing the NCT6687
+			 * map onto them at minimum produces nonsense readings and
+			 * at worst writes to unknown control bits that can leave
+			 * the EC in a state the BIOS can no longer recover.
+			 *
+			 * If you reach this branch the right move is usually to
+			 * add the chip ID to the explicit switch above, after
+			 * verifying the register map matches; force is meant for
+			 * experimentation with brand-new NCT668x variants, not
+			 * for cross-vendor attachment.
+			 */
+			if ((val & 0xF000) != 0xD000)
+			{
+				pr_warn("force=1 refused: chip ID 0x%04x is outside the Nuvoton NCT668x range (0xD000-0xDFFF); attach the vendor-appropriate driver instead\n",
+					val);
+				goto fail;
+			}
+			pr_warn("force=1: attaching nct6687 to unrecognised chip ID 0x%04x in the NCT668x range — readings may be incorrect, please file a support request with the board's DMI info\n",
+				val);
 			sio_data->kind = nct6687;
 			break;
 		}


### PR DESCRIPTION
## Problem

The \`force\` module parameter currently lets the driver attach to **any** chip ID it does not recognise:

\`\`\`c
default:
    if (force) {
        sio_data->kind = nct6687;
        break;
    }
    goto fail;
\`\`\`

That includes chip IDs from other vendors entirely:
- ITE IT8625E → 0x8625
- Fintek F71808A → 0x0815
- Nuvoton's **own** NCT6791D → 0xc803 (different register map; mainline \`nct6775\`)

Forcing the NCT6687 register map onto them produces nonsense at best and, since the driver writes to control registers (PWM, fan-mode-config), can leave the EC in a state the BIOS can no longer recover at worst.

## Fix

Restrict \`force=1\` to chip IDs whose upper nibble is **0xD** — covers known NCT668x variants and admits future 0xd6xx/0xd7xx parts likely in the same family. Add loud pr_warns on both the refused-force and the proceeding-with-force paths so the user sees what's happening.

\`\`\`
force=1 refused: chip ID 0xNNNN is outside the Nuvoton NCT668x range
  (0xD000-0xDFFF); attach the vendor-appropriate driver instead

force=1: attaching nct6687 to unrecognised chip ID 0xNNNN in the
  NCT668x range — readings may be incorrect, please file a support
  request with the board's DMI info
\`\`\`

## Test plan

- Built on Fedora 44 / 7.0.8-200.fc44 and Proxmox 7.0.2-3-pve.
- MSI PRO Z690-A DDR4 (MS-7D25) chip 0xD590 is matched by the explicit case, so \`force\` never fires; build clean, module loads as before.
- New dmesg strings verified present in the .ko via \`strings(1)\`.

## Compatibility note

Users who currently use \`force=1\` on a non-Nuvoton chip will now see the refusal warning and need to use the correct vendor driver instead. That is the safer behaviour given what the alternative can do to a board.