### PR TITLE
fix: use s32 for voltage values to avoid overflow on the +12V rail

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -512,8 +512,13 @@ struct nct6687_data
 	bool valid;					/* true if following fields are valid */
 	unsigned long last_updated; /* In jiffies */
 
-	/* Voltage values */
-	s16 voltage[3][NCT6687_NUM_REG_VOLTAGE]; // 0 = current 1 = min 2 = max
+	/*
+	 * Voltage values in mV (hwmon ABI). s32 rather than s16 because a
+	 * 12-bit raw reading multiplied by the +12V definition's multiplier
+	 * of 12 peaks around 49140 mV — past the 32767 ceiling of s16.
+	 * Index 0 = current, 1 = running min, 2 = running max.
+	 */
+	s32 voltage[3][NCT6687_NUM_REG_VOLTAGE];
 
 	/* Temperature values */
 	s32 temperature[3][NCT6687_NUM_REG_TEMP]; // 0 = current 1 = min 2 = max
@@ -775,7 +780,12 @@ static void nct6687_update_voltage(struct nct6687_data *data)
 		s16 high = nct6687_read(data, NCT6687_REG_VOLTAGE(reg)) * 16;
 		s16 low = ((u16)nct6687_read(data, NCT6687_REG_VOLTAGE(reg) + 1)) >> 4;
 		s16 value = low + high;
-		s16 voltage = manual ? value : value * nct6687_voltage_definition[index].multiplier;
+		/*
+		 * value (max 4095) * multiplier (12 for +12V rail) reaches
+		 * ~49140 mV, which overflows s16. Use s32 to keep rail values
+		 * correct under worst-case inputs.
+		 */
+		s32 voltage = manual ? value : value * nct6687_voltage_definition[index].multiplier;
 
 		data->voltage[0][index] = voltage;
 		data->voltage[1][index] = MIN(voltage, data->voltage[1][index]);
@@ -1295,7 +1305,7 @@ static void nct6687_setup_voltages(struct nct6687_data *data)
 		s16 high = nct6687_read(data, NCT6687_REG_VOLTAGE(reg)) * 16;
 		s16 low = ((u16)nct6687_read(data, NCT6687_REG_VOLTAGE(reg) + 1)) >> 4;
 		s16 value = low + high;
-		s16 voltage = manual ? value : value * nct6687_voltage_definition[index].multiplier;
+		s32 voltage = manual ? value : value * nct6687_voltage_definition[index].multiplier;
 
 		data->voltage[0][index] = voltage;
 		data->voltage[1][index] = voltage;


### PR DESCRIPTION
## Problem

\`nct6687_update_voltage\` composes a millivolt reading as:

\`\`\`c
s16 high  = (raw_byte0 << 4);           // up to 4080
s16 low   = raw_byte1 >> 4;             // up to 15
s16 value = low + high;                 // up to 4095, fits s16
s16 voltage = value * multiplier;       // <-- overflow window
\`\`\`

For the +12V definition (\`multiplier = 12\`), worst-case scaled voltage is **4095 × 12 = 49140 mV** — past the **32767** ceiling of \`s16\`. Real-world boards currently read around 12000-13000 mV so the bug is **latent**, but:

- a board with a slightly-different ratio register
- a new chip variant whose +12V definition picks a different multiplier
- a transient ADC glitch on existing hardware

can push the value into the overflow window and report a negative number sensors-side.

## Fix

Promote the local \`voltage\` variable and the \`data->voltage\` struct field to \`s32\`. The intermediate \`high\` / \`low\` / \`value\` only reach 4095 and stay \`s16\`.

## Test plan

Built on Fedora 44 / 7.0.8-200.fc44 and Proxmox 7.0.2-3-pve.

On MSI PRO Z690-A DDR4 (MS-7D25), voltage readings unchanged in the normal-input regime:

| Rail | After patch |
|---|---|
| \`+12V (in0)\` | 12048 mV |
| \`+5V (in1)\` | 4920 mV |
| \`Vcore (in4)\` | 722 mV |

## Notes

This is a hwmon-ABI conformance fix: the millivolt sysfs values are documented as signed integers, and userspace will read them as signed. The previous code was technically out-of-spec for the +12V rail even though it never tripped on this specific hardware.