### PR TITLE
polish: modernise platform_driver.remove signature; add MODULE_VERSION

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -37,6 +37,7 @@
 #include <linux/mutex.h>
 #include <linux/platform_device.h>
 #include <linux/slab.h>
+#include <linux/version.h>
 
 #define DRVNAME "nct6687"
 
@@ -1342,7 +1343,22 @@ static void nct6687_setup_pwm(struct nct6687_data *data)
 	}
 }
 
+/*
+ * platform_driver.remove's signature changed from
+ *   int  (*remove)(struct platform_device *)
+ * to
+ *   void (*remove)(struct platform_device *)
+ * in 6.11 (kernel commit 0edb555a6).
+ *
+ * Conditionally compile the signature so we can drop the
+ * -Wincompatible-pointer-types pragma from around the
+ * platform_driver struct.
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int nct6687_remove(struct platform_device *pdev)
+#else
+static void nct6687_remove(struct platform_device *pdev)
+#endif
 {
 	struct device *dev = &pdev->dev;
 	struct nct6687_data *data = dev_get_drvdata(dev);
@@ -1357,7 +1373,9 @@ static int nct6687_remove(struct platform_device *pdev)
 
 	mutex_unlock(&data->update_lock);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static int nct6687_probe(struct platform_device *pdev)
@@ -1491,8 +1509,6 @@ static int nct6687_resume(struct platform_device *pdev)
 
 #define NCT6687_DEV_PM_OPS NULL
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
 static struct platform_driver nct6687_driver = {
 	.driver = {
 		.name = DRVNAME,
@@ -1503,7 +1519,6 @@ static struct platform_driver nct6687_driver = {
 	.suspend = nct6687_suspend,
 	.resume = nct6687_resume,
 };
-#pragma GCC diagnostic pop
 
 static int __init nct6687_find(int sioaddr, struct nct6687_sio_data *sio_data)
 {
@@ -1705,6 +1720,7 @@ static void __exit sensors_nct6687_exit(void)
 MODULE_AUTHOR("Frederic Boltz <frederic.boltz@gmail.com>");
 MODULE_DESCRIPTION("Driver for NCT6687D");
 MODULE_LICENSE("GPL");
+MODULE_VERSION("1.0.0");
 
 module_init(sensors_nct6687_init);
 module_exit(sensors_nct6687_exit);


### PR DESCRIPTION
Two small modernisation fixes bundled because they touch the same area.

## 1. \`platform_driver.remove\` signature

The kernel changed \`platform_driver.remove\` from \`int (*)(struct platform_device *)\` to \`void (*)(struct platform_device *)\` in 6.11 ([torvalds/0edb555a6](https://git.kernel.org/torvalds/c/0edb555a6)). The driver currently silences the resulting \`-Wincompatible-pointer-types\` warning with a GCC pragma:

\`\`\`c
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
static struct platform_driver nct6687_driver = { ... };
#pragma GCC diagnostic pop
\`\`\`

Replace the pragma with a proper \`LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)\` conditional that picks the matching signature for the running kernel. The warning was a real type mismatch — static analysers and LLVM builds saw a different pointer type than the kernel expects to call, and the pragma made that invisible.

## 2. \`MODULE_VERSION\`

\`modinfo nct6687\` currently shows no \`version:\` line. Tools that scrape modinfo for diagnostics (lm-sensors, distro QA bots, downstream daemons) have nothing to anchor a "what version of this driver is installed" question to. Add \`MODULE_VERSION("1.0.0")\`.

## Test plan

Built and loaded on:
- Fedora 44 / 7.0.8-200.fc44 (post-6.11 path)
- Proxmox 7.0.2-3-pve (post-6.11 path)

\`modinfo\` now shows:
\`\`\`
version:        1.0.0
description:    Driver for NCT6687D
author:         Frederic Boltz <frederic.boltz@gmail.com>
\`\`\`

Module loads / unloads cleanly, no compiler warnings remain.

The pre-6.11 path is not exercised by these test hosts; the conditional itself is the standard idiom every in-tree platform_driver that lived through the 6.11 transition adopted (see e.g. \`drivers/hwmon/dell-smm-hwmon.c\`).