### PR TITLE
Add MSI B850 GAMING PRO WIFI6E

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -430,6 +430,7 @@ static const struct dmi_system_id nct6687_msi_alt_boards[] = {
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B850 GAMING PLUS WIFI (MS-7E56)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B850 GAMING PLUS WIFI6E (MS-7E80)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B850M GAMING PLUS WIFI6E (MS-7E81)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B850 GAMING PRO WIFI6E (MS-7E89)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B850-P WIFI (MS-7E56)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B850M-A WIFI (MS-7E66)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B850M-P WIFI (MS-7E71)")}},


### PR DESCRIPTION
Adds DMI support for MSI B850 GAMING PRO WIFI6E (MS-7E89) to the nct6687_msi_alt_boards table.

Without this entry, the board falls back to the default fan configuration which caused incorrect SYS_FAN RPM/PWM mappings. This board appears to use the same MSI alternate fan layout as other supported B850 MSI boards. Was able to control and view every fan header with this change using fan_config=msi_alt1.

Tested on:

MSI B850 GAMING PRO WIFI6E (MS-7E89)
Arch Linux
Linux 6.18.32-lts
nct6687d-dkms-git r191.4d1600b