### PR TITLE
Add DMI board match support for MSI MAG B860M Mortar WiFi

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -440,6 +440,9 @@ static const struct dmi_system_id nct6687_msi_alt_boards[] = {
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "B850MPOWER (MS-7E83)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO B850-S WIFI6E (MS-7E80)")}},
 
+        // B860 Series
+        {.matches = {DMI_MATCH(DMI_BOARD_NAME, "MAG B860M MORTAR WIFI (MS-7E40)")}},
+
 	// X870 Series
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "X870 GAMING PLUS WIFI (MS-7E47)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "X870E GAMING PLUS WIFI (MS-7E70)")}},


### PR DESCRIPTION
Adds DMI support for MAG B860M MORTAR WIFI (MS-7E40) to the nct6687_msi_alt_boards table.

Without this entry, the board falls back to the default fan configuration which caused incorrect SYS_FAN RPM/PWM mappings. This board appears to use the same MSI alternate fan layout as other supported B850 MSI boards. Was able to control and view every fan header with this change using fan_config=msi_alt1.

Tested on:

MAG B860M MORTAR WIFI (MS-7E40)
7.0.2-6-pve