### PR TITLE
Replaced strncpy with strscpy

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -477,7 +477,7 @@ static int nct6687_fan_config_op_write_handler(const char *val, const struct ker
 	char valcp[16];
 	char *s;
 
-	strncpy(valcp, val, 16);
+	strscpy(valcp, val, 16);
 	valcp[15] = '\0';
 
 	s = strstrip(valcp);


### PR DESCRIPTION
In kernel 7.2-rc1 strncpy has been removed.

Replacing it with strscpy make nct6687d compile and run correctly again (on my own machine: MSI x570s edge max wifi)