### PR TITLE
Add MSI MEG Z890 GODLIKE (MS-7E21) to msi_alt1 board list

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -474,6 +474,7 @@ static const struct dmi_system_id nct6687_msi_alt_boards[] = {
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MEG X870E GODLIKE (MS-7E48)")}},
 
 	// Z890 Series
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MEG Z890 GODLIKE (MS-7E21)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MEG Z890 ACE (MS-7E22)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MEG Z890M ACE (MS-7E23)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "MPG Z890 CARBON WIFI (MS-7E17)")}},


### PR DESCRIPTION
The board uses the NCT6687DR chip and requires the msi_alt1 fan register mapping. Without this entry the driver falls back to the default mapping and all six SYS_FAN inputs report 0 RPM.

Verified on Debian 13, MSI MEG Z890 GODLIKE: before the change only CPU Fan, Pump Fan and System Fan #1 reported values; after it all six system fans report correct RPM matching the BIOS hardware monitor.