### PR TITLE
hwmon: clean up fan attribute and curve handling

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -1298,9 +1298,12 @@ static ssize_t store_pwm(struct device *dev, struct device_attribute *attr, cons
 
 	if (nct6687_uses_msi_fan_curve(index))
 	{
-		if (!nct6687_curve_matches(data, NCT6687_REG_PWM_WRITE(index), val))
-			nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), val);
 		success = nct6687_curve_matches(data, NCT6687_REG_PWM_WRITE(index), val);
+		if (!success)
+		{
+			nct6687_write_all_curve(data, NCT6687_REG_PWM_WRITE(index), val);
+			success = nct6687_curve_matches(data, NCT6687_REG_PWM_WRITE(index), val);
+		}
 		if (!success)
 			pr_err("Failed to verify MSI fan %d curve write\n", index);
 	}

--- a/nct6687.c
+++ b/nct6687.c
@@ -701,7 +701,7 @@ static struct attribute_group *nct6687_create_attr_group(struct device *dev, con
 	struct sensor_device_attr_u *su;
 	struct attribute_group *group;
 	struct attribute **attrs;
-	int i, j, count;
+	int i, count;
 
 	if (repeat <= 0)
 		return ERR_PTR(-EINVAL);
@@ -732,7 +732,7 @@ static struct attribute_group *nct6687_create_attr_group(struct device *dev, con
 	{
 		t = tg->templates;
 
-		for (j = 0; *t != NULL; j++)
+		while (*t != NULL)
 		{
 			snprintf(su->name, sizeof(su->name), (*t)->dev_attr.attr.name, tg->base + i);
 


### PR DESCRIPTION
Howdy @Fred78290 <3

I removed an unused loop variable and simplified the MSI fan curve write check from PR #190 by reusing the initial result.