### PR TITLE
Add DMI match for MSI PRO Z890-S WIFI WHITE (MS-7E54)

### DIFF
--- a/nct6687.c
+++ b/nct6687.c
@@ -509,6 +509,7 @@ static const struct dmi_system_id nct6687_msi_alt_boards[] = {
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO Z890-A WIFI (MS-7E32)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO Z890-P WIFI (MS-7E34)")}},
 	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO Z890-S WIFI (MS-7E54)")}},
+	{.matches = {DMI_MATCH(DMI_BOARD_NAME, "PRO Z890-S WIFI WHITE (MS-7E54)")}},
 	{}};
 
 static int nct6687_fan_config_type = FAN_CONFIG_DEFAULT; // default


### PR DESCRIPTION
## Symptom

On MSI PRO Z890-S WIFI WHITE (MS-7E54) all SYS_FAN channels read 0 RPM and PWM writes are silently ignored, while CPU Fan / Pump Fan keep working.

## Root cause

The WHITE variant reports DMI_BOARD_NAME `PRO Z890-S WIFI WHITE (MS-7E54)`, but the existing entry only matches `PRO Z890-S WIFI (MS-7E54)`. The substring DMI_MATCH therefore fails, `nct6687_msi_alt_boards[]` does not fire, and the driver falls back to the default register mapping. On this NCT6687DR board the system fan registers live in the msi_alt1 layout (RPM 0x154-0x15E, PWM write 0xBF8-0xC70), so the default mapping hits the wrong offsets. CPU/Pump channels are unaffected because their registers (0xA28/0xA29) are identical in both mappings.

## Fix

Add the WHITE variant to `nct6687_msi_alt_boards[]` so the msi_alt1 mapping is selected automatically.

## Tested

MSI PRO Z890-S WIFI WHITE (MS-7E54), kernel 7.0.0-30-generic: with the patch the driver auto-selects msi_alt1; System Fan tach values read correctly and PWM writes take effect.
